### PR TITLE
Feat: Set order signed links in order resource

### DIFF
--- a/packages/api/src/Domain/Carts/Http/Controllers/CheckoutCartController.php
+++ b/packages/api/src/Domain/Carts/Http/Controllers/CheckoutCartController.php
@@ -35,7 +35,6 @@ class CheckoutCartController extends Controller implements CheckoutCartControlle
         /** @var Order $order */
         $order = ($checkoutCartAction)($cart);
 
-        // TODO: Refactor to default json:api links
         return DataResponse::make($order)
             ->withIncludePaths([
                 'product_lines',

--- a/packages/api/src/Domain/Carts/Http/Controllers/CheckoutCartController.php
+++ b/packages/api/src/Domain/Carts/Http/Controllers/CheckoutCartController.php
@@ -10,7 +10,6 @@ use Dystore\Api\Domain\Carts\Contracts\CurrentSessionCart;
 use Dystore\Api\Domain\Carts\JsonApi\V1\CheckoutCartRequest;
 use Dystore\Api\Domain\Carts\Models\Cart;
 use Dystore\Api\Domain\Orders\Models\Order;
-use Illuminate\Support\Facades\URL;
 use LaravelJsonApi\Contracts\Store\Store as StoreContract;
 use LaravelJsonApi\Core\Responses\DataResponse;
 
@@ -40,28 +39,6 @@ class CheckoutCartController extends Controller implements CheckoutCartControlle
         return DataResponse::make($order)
             ->withIncludePaths([
                 'product_lines',
-            ])
-            ->withLinks([
-                'self.signed' => URL::signedRoute(
-                    'v1.orders.show',
-                    ['order' => $order->getRouteKey()],
-                ),
-                'create-payment-intent.signed' => URL::signedRoute(
-                    'v1.orders.createPaymentIntent',
-                    ['order' => $order->getRouteKey()],
-                ),
-                'mark-order-pending-payment.signed' => URL::signedRoute(
-                    'v1.orders.markPendingPayment',
-                    ['order' => $order->getRouteKey()],
-                ),
-                'mark-order-awaiting-payment.signed' => URL::signedRoute(
-                    'v1.orders.markAwaitingPayment',
-                    ['order' => $order->getRouteKey()],
-                ),
-                'check-order-payment-status.signed' => URL::signedRoute(
-                    'v1.orders.checkOrderPaymentStatus',
-                    ['order' => $order->getRouteKey()],
-                ),
             ])
             ->didCreate();
     }

--- a/packages/api/src/Domain/Orders/Http/Controllers/OrdersController.php
+++ b/packages/api/src/Domain/Orders/Http/Controllers/OrdersController.php
@@ -7,7 +7,6 @@ use Dystore\Api\Domain\Orders\Contracts\OrdersController as OrdersControllerCont
 use Dystore\Api\Domain\Orders\JsonApi\V1\OrderQuery;
 use Dystore\Api\Domain\Orders\JsonApi\V1\OrderSchema;
 use Dystore\Api\Domain\Orders\Models\Order;
-use Illuminate\Support\Facades\URL;
 use LaravelJsonApi\Core\Responses\DataResponse;
 use LaravelJsonApi\Laravel\Http\Controllers\Actions\FetchOne;
 use LaravelJsonApi\Laravel\Http\Controllers\Actions\FetchRelated;
@@ -37,28 +36,6 @@ class OrdersController extends Controller implements OrdersControllerContract
             ->first();
 
         return DataResponse::make($model)
-            ->withLinks([
-                'self.signed' => URL::signedRoute(
-                    'v1.orders.show',
-                    ['order' => $model->getRouteKey()],
-                ),
-                'create-payment-intent.signed' => URL::signedRoute(
-                    'v1.orders.createPaymentIntent',
-                    ['order' => $model->getRouteKey()],
-                ),
-                'mark-order-pending-payment.signed' => URL::signedRoute(
-                    'v1.orders.markPendingPayment',
-                    ['order' => $model->getRouteKey()],
-                ),
-                'mark-order-awaiting-payment.signed' => URL::signedRoute(
-                    'v1.orders.markAwaitingPayment',
-                    ['order' => $model->getRouteKey()],
-                ),
-                'check-order-payment-status.signed' => URL::signedRoute(
-                    'v1.orders.checkOrderPaymentStatus',
-                    ['order' => $model->getRouteKey()],
-                ),
-            ])
             ->didntCreate();
     }
 }

--- a/packages/api/src/Domain/Orders/JsonApi/V1/OrderResource.php
+++ b/packages/api/src/Domain/Orders/JsonApi/V1/OrderResource.php
@@ -55,6 +55,16 @@ class OrderResource extends JsonApiResource
      */
     public function links($request): Links
     {
+        $links = new Links;
+
+        if ($self = $this->selfLink()) {
+            $links->push($self);
+        }
+
+        if (! $this->hasSignedUrls()) {
+            return $links;
+        }
+
         $signedUrls = [
             new Link(
                 'self.signed',
@@ -93,10 +103,8 @@ class OrderResource extends JsonApiResource
             ),
         ];
 
-        return new Links(
-            $this->selfLink(),
+        $links->push(...$signedUrls);
 
-            ...$this->hasSignedUrls() ? $signedUrls : [],
-        );
+        return $links;
     }
 }

--- a/packages/api/src/Domain/Orders/JsonApi/V1/OrderResource.php
+++ b/packages/api/src/Domain/Orders/JsonApi/V1/OrderResource.php
@@ -2,8 +2,10 @@
 
 namespace Dystore\Api\Domain\Orders\JsonApi\V1;
 
+use Dystore\Api\Domain\Checkout\Enums\CheckoutProtectionStrategy;
 use Dystore\Api\Domain\JsonApi\Resources\JsonApiResource;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\URL;
 use LaravelJsonApi\Core\Document\Link;
 use LaravelJsonApi\Core\Document\Links;
@@ -20,66 +22,81 @@ class OrderResource extends JsonApiResource
         return parent::attributes($request);
     }
 
-    // /**
-    //  * Get the resource's `self` link URL.
-    //  */
-    // public function selfUrl(): string
-    // {
-    //     if ($this->selfUri) {
-    //         return $this->selfUri;
-    //     }
-    //
-    //     return $this->selfUri = URL::signedRoute(
-    //         'v1.orders.show',
-    //         ['order' => $this->id()],
-    //     );
-    // }
+    /**
+     * Get the resource's `self` link URL.
+     */
+    public function selfUrl(): string
+    {
+        if ($this->selfUri) {
+            return $this->selfUri;
+        }
 
-    // /**
-    //  * Get the resource's links.
-    //  *
-    //  * @param  \Illuminate\Http\Request|null  $request
-    //  */
-    // public function links($request): Links
-    // {
-    //     return new Links(
-    //         $this->selfLink(),
-    //
-    //         new Link(
-    //             'self.signed',
-    //             URL::signedRoute(
-    //                 'v1.orders.show',
-    //                 ['order' => $this->id()],
-    //             ),
-    //         ),
-    //         new Link(
-    //             'create-payment-intent.signed',
-    //             URL::signedRoute(
-    //                 'v1.orders.createPaymentIntent',
-    //                 ['order' => $this->id()],
-    //             ),
-    //         ),
-    //         new Link(
-    //             'mark-order-pending-payment.signed',
-    //             URL::signedRoute(
-    //                 'v1.orders.markPendingPayment',
-    //                 ['order' => $this->id()],
-    //             ),
-    //         ),
-    //         new Link(
-    //             'mark-order-awaiting-payment.signed',
-    //             URL::signedRoute(
-    //                 'v1.orders.markAwaitingPayment',
-    //                 ['order' => $this->id()],
-    //             ),
-    //         ),
-    //         new Link(
-    //             'check-order-payment-status.signed',
-    //             URL::signedRoute(
-    //                 'v1.orders.checkOrderPaymentStatus',
-    //                 ['order' => $this->id()],
-    //             ),
-    //         ),
-    //     );
-    // }
+        // if ($this->hasSignedUrls()) {
+        //     return URL::signedRoute(
+        //         'v1.orders.show',
+        //         ['order' => $this->id()],
+        //     );
+        // }
+
+        return parent::selfUrl();
+    }
+
+    private function hasSignedUrls(): bool
+    {
+        $protectionStrategy = Config::get('dystore.general.checkout.checkout_protection_strategy');
+
+        return $protectionStrategy === CheckoutProtectionStrategy::SIGNATURE;
+    }
+
+    /**
+     * Get the resource's links.
+     *
+     * @param  \Illuminate\Http\Request|null  $request
+     */
+    public function links($request): Links
+    {
+        $signedUrls = [
+            new Link(
+                'self.signed',
+                URL::signedRoute(
+                    'v1.orders.show',
+                    ['order' => $this->id()],
+                ),
+            ),
+            new Link(
+                'create-payment-intent.signed',
+                URL::signedRoute(
+                    'v1.orders.createPaymentIntent',
+                    ['order' => $this->id()],
+                ),
+            ),
+            new Link(
+                'mark-order-pending-payment.signed',
+                URL::signedRoute(
+                    'v1.orders.markPendingPayment',
+                    ['order' => $this->id()],
+                ),
+            ),
+            new Link(
+                'mark-order-awaiting-payment.signed',
+                URL::signedRoute(
+                    'v1.orders.markAwaitingPayment',
+                    ['order' => $this->id()],
+                ),
+            ),
+            new Link(
+                'check-order-payment-status.signed',
+                URL::signedRoute(
+                    'v1.orders.checkOrderPaymentStatus',
+                    ['order' => $this->id()],
+                ),
+            ),
+        ];
+
+        return new Links(
+            $this->selfLink(),
+
+            ...$this->hasSignedUrls() ? $signedUrls : [],
+        );
+    }
 }

--- a/tests/api/Feature/Domain/Orders/JsonApi/V1/ReadOrderTest.php
+++ b/tests/api/Feature/Domain/Orders/JsonApi/V1/ReadOrderTest.php
@@ -87,7 +87,7 @@ it('can read order details when accessing order with valid signature', function 
         ])
         ->post(serverUrl('/carts/-actions/checkout'));
 
-    $signedUrl = $response->json()['links']['self.signed'];
+    $signedUrl = $response->json('data.links')['self.signed'];
 
     $order = Order::query()
         ->where('cart_id', $cart->getKey())
@@ -99,14 +99,18 @@ it('can read order details when accessing order with valid signature', function 
         ->get($signedUrl);
 
     $response
-        ->assertFetchedOne($order)
         ->assertSuccessful()
-        ->assertLinks([
-            'self.signed' => $response->json()['links']['self.signed'],
-            'create-payment-intent.signed' => $response->json()['links']['create-payment-intent.signed'],
-            'mark-order-pending-payment.signed' => $response->json()['links']['mark-order-pending-payment.signed'],
-            'mark-order-awaiting-payment.signed' => $response->json()['links']['mark-order-awaiting-payment.signed'],
-            'check-order-payment-status.signed' => $response->json()['links']['check-order-payment-status.signed'],
+        ->assertFetchedOne([
+            'type' => 'orders',
+            'id' => (string) $order->getRouteKey(),
+            'links' => [
+                'self' => $response->json('data.links.self'),
+                'self.signed' => $response->json('data.links')['self.signed'],
+                'create-payment-intent.signed' => $response->json('data.links')['create-payment-intent.signed'],
+                'mark-order-pending-payment.signed' => $response->json('data.links')['mark-order-pending-payment.signed'],
+                'mark-order-awaiting-payment.signed' => $response->json('data.links')['mark-order-awaiting-payment.signed'],
+                'check-order-payment-status.signed' => $response->json('data.links')['check-order-payment-status.signed'],
+            ],
         ]);
 
 })->group('orders');


### PR DESCRIPTION
* Order signed links are now set in `OrderResource` (if signature checkout protection strategy applied)
* Removed `withLinks` method from controllers