### PR TITLE
Fix: Fix payment authorization

### DIFF
--- a/packages/api/src/Domain/Payments/Actions/AuthorizeOfflinePayment.php
+++ b/packages/api/src/Domain/Payments/Actions/AuthorizeOfflinePayment.php
@@ -3,6 +3,7 @@
 namespace Dystore\Api\Domain\Payments\Actions;
 
 use Dystore\Api\Domain\Orders\Events\OrderPaymentSuccessful;
+use Dystore\Api\Domain\Payments\PaymentTypes\OfflinePaymentType;
 use Lunar\Base\DataTransferObjects\PaymentAuthorize;
 use Lunar\Facades\Payments;
 use Lunar\Models\Contracts\Cart as CartContract;
@@ -13,22 +14,36 @@ class AuthorizeOfflinePayment
     /**
      * @param  array<string,mixed>  $meta
      */
-    public function __invoke(OrderContract $order, CartContract $cart, string $paymentType = 'offline', ?array $meta = null): void
+    public function __invoke(?OrderContract $order, ?CartContract $cart, string $paymentType = 'offline', ?array $meta = null): void
     {
-        /** @var PaymentAuthorize $payment */
-        $payment = Payments::driver('offline')
-            ->order($order)
-            ->cart($cart)
+        if (! $order && ! $cart) {
+            throw new \InvalidArgumentException('Either order or cart must be provided');
+        }
+
+        /** @var OfflinePaymentType $driver */
+        $driver = Payments::driver('offline');
+
+        if ($cart) {
+            $driver->cart($cart);
+        }
+
+        if ($order) {
+            $driver->order($order);
+        }
+
+        $driver
             ->withData([
                 'meta' => array_merge(
                     ['payment_type' => $paymentType],
                     $meta ?? [],
                 ),
-            ])
-            ->authorize($paymentType);
+            ]);
 
-        if (! $payment->success) {
-            report("Payment failed for order: {$order->id} with reason: {$payment->message}");
+        /** @var PaymentAuthorize $authorization */
+        $authorization = $driver->authorize($paymentType);
+
+        if (! $authorization->success) {
+            report("Payment failed for order: {$order->id} with reason: {$authorization->message}");
 
             return;
         }

--- a/packages/api/src/Domain/Payments/PaymentTypes/OfflinePaymentType.php
+++ b/packages/api/src/Domain/Payments/PaymentTypes/OfflinePaymentType.php
@@ -10,6 +10,9 @@ use Dystore\Api\Domain\Payments\PaymentAdapters\PaymentAdaptersRegister;
 use Lunar\Base\DataTransferObjects\PaymentAuthorize;
 use Lunar\Base\DataTransferObjects\PaymentCapture;
 use Lunar\Base\DataTransferObjects\PaymentRefund;
+use Lunar\Events\PaymentAttemptEvent;
+use Lunar\Exceptions\Carts\CartException;
+use Lunar\Exceptions\DisallowMultipleCartOrdersException;
 use Lunar\Models\Contracts\Transaction as TransactionContract;
 use Lunar\PaymentTypes\AbstractPayment;
 
@@ -24,6 +27,16 @@ class OfflinePaymentType extends AbstractPayment
      */
     public function authorize(string $paymentType = 'offline'): PaymentAuthorize
     {
+        $this->order = $this->order ?: ($this->cart->draftOrder ?: $this->cart->completedOrder);
+
+        if (! $this->order) {
+            try {
+                $this->order = $this->cart->createOrder();
+            } catch (DisallowMultipleCartOrdersException|CartException $e) {
+                return $this->failedAuthorization($e->getMessage(), $paymentType);
+            }
+        }
+
         $meta = array_merge(
             (array) $this->order->meta,
             $this->data['meta'] ?? []
@@ -39,11 +52,31 @@ class OfflinePaymentType extends AbstractPayment
 
         $this->createCaptureTransaction($paymentType);
 
-        return new PaymentAuthorize(
+        $authorization = new PaymentAuthorize(
             success: true,
             orderId: $this->order->id,
             paymentType: $paymentType,
         );
+
+        PaymentAttemptEvent::dispatch($authorization);
+
+        return $authorization;
+    }
+
+    public function failedAuthorization(
+        string $message = 'Failed to authorize payment',
+        string $paymentType = 'offline',
+    ): PaymentAuthorize {
+        $failure = new PaymentAuthorize(
+            success: false,
+            message: $message,
+            orderId: $this->order?->id,
+            paymentType: 'bank-transfer'
+        );
+
+        PaymentAttemptEvent::dispatch($failure);
+
+        return $failure;
     }
 
     /**

--- a/packages/api/src/Domain/Payments/PaymentTypes/OfflinePaymentType.php
+++ b/packages/api/src/Domain/Payments/PaymentTypes/OfflinePaymentType.php
@@ -39,7 +39,11 @@ class OfflinePaymentType extends AbstractPayment
 
         $this->createCaptureTransaction($paymentType);
 
-        return new PaymentAuthorize(true);
+        return new PaymentAuthorize(
+            success: true,
+            orderId: $this->order->id,
+            paymentType: $paymentType,
+        );
     }
 
     /**

--- a/packages/stripe/src/Actions/AuthorizeStripePayment.php
+++ b/packages/stripe/src/Actions/AuthorizeStripePayment.php
@@ -6,25 +6,41 @@ use Dystore\Api\Domain\Orders\Events\OrderPaymentSuccessful;
 use Dystore\Api\Domain\Payments\Contracts\PaymentIntent;
 use Lunar\Base\DataTransferObjects\PaymentAuthorize;
 use Lunar\Facades\Payments;
-use Lunar\Models\Contracts\Cart;
-use Lunar\Models\Contracts\Order;
+use Lunar\Models\Contracts\Cart as CartContract;
+use Lunar\Models\Contracts\Order as OrderContract;
+use Lunar\Stripe\StripePaymentType;
 
 class AuthorizeStripePayment
 {
-    public function __invoke(Order $order, Cart $cart, PaymentIntent $intent): void
+    public function __invoke(?OrderContract $order, ?CartContract $cart, PaymentIntent $intent): void
     {
+        if (! $order && ! $cart) {
+            throw new \InvalidArgumentException('Either order or cart must be provided');
+        }
+
+        /** @var StripePaymentType $driver */
+        $driver = Payments::driver('stripe');
+
+        if ($cart) {
+            $driver->cart($cart);
+        }
+
+        if ($order) {
+            $driver->order($order);
+        }
+
         /** @var PaymentAuthorize $payment */
-        $payment = Payments::driver('stripe')
-            ->order($order)
-            ->cart($cart)
+        $driver
             ->withData([
                 'payment_intent_client_secret' => $intent->getClientSecret(),
                 'payment_intent' => $intent->getId(),
-            ])
-            ->authorize();
+            ]);
 
-        if (! $payment->success) {
-            report("Payment failed for order: {$order->id} with reason: {$payment->message}");
+        /** @var PaymentAuthorize $authorization */
+        $authorization = $driver->authorize();
+
+        if (! $authorization->success) {
+            report("Payment failed for order: {$order->id} with reason: {$authorization->message}");
 
             return;
         }

--- a/tests/api/Feature/Domain/Storefront/JsonApi/V1/ForgetStorefrontTest.php
+++ b/tests/api/Feature/Domain/Storefront/JsonApi/V1/ForgetStorefrontTest.php
@@ -41,7 +41,7 @@ it('can forget storefront session', function () {
     $storefrontSession->setCustomer($customer);
     $storefrontSession->setCustomerGroups($customerGroups);
 
-    ray($storefrontSession);
+    // ray($storefrontSession);
 
     $response = $this
         ->jsonApi()


### PR DESCRIPTION
## Description

* There was an issue with offline payment authorization, because when we set cart on payment type, it unsets order and vice versa. We now check the existence of cart or order with order having a priority over cart (it would get fetched or instantiated anyway in case of `StripePaymentType` authorization).
* Added `failedAuthorization` method to `OfflinePaymentType`.

## Type of Change

-   [x] Bug fix
-   [ ] New feature
-   [ ] Breaking change
