### PR TITLE
Quick fix: Rename method to fail

### DIFF
--- a/packages/api/src/Domain/Payments/PaymentTypes/OfflinePaymentType.php
+++ b/packages/api/src/Domain/Payments/PaymentTypes/OfflinePaymentType.php
@@ -33,7 +33,10 @@ class OfflinePaymentType extends AbstractPayment
             try {
                 $this->order = $this->cart->createOrder();
             } catch (DisallowMultipleCartOrdersException|CartException $e) {
-                return $this->failedAuthorization($e->getMessage(), $paymentType);
+                return $this->fail(
+                    message: $e->getMessage(),
+                    paymentType: $paymentType,
+                );
             }
         }
 
@@ -63,7 +66,7 @@ class OfflinePaymentType extends AbstractPayment
         return $authorization;
     }
 
-    public function failedAuthorization(
+    public function fail(
         string $message = 'Failed to authorize payment',
         string $paymentType = 'offline',
     ): PaymentAuthorize {


### PR DESCRIPTION
* Renamed `failedAuthorization` method to `fail` in `OfflinePaymentType`
* Added handling of hidden payment options (useful for implementing manual bank transfer payment option etc.)