### PR TITLE
Feature/handle hidden payment options

### DIFF
--- a/packages/api/src/Domain/PaymentOptions/Contracts/PaymentManifest.php
+++ b/packages/api/src/Domain/PaymentOptions/Contracts/PaymentManifest.php
@@ -35,16 +35,18 @@ interface PaymentManifest
 
     /**
      * Return available options for a given cart.
+     *
+     * @return Collection<PaymentOption>
      */
-    public function getOptions(CartContract $cart): Collection;
+    public function getOptions(CartContract $cart, bool $withHidden): Collection;
 
     /**
      * Return available option for a given cart by identifier.
      */
-    public function getOption(CartContract $cart, string $identifier): ?PaymentOption;
+    public function getOption(CartContract $cart, string $identifier, bool $withHidden): ?PaymentOption;
 
     /**
      * Retrieve payment option for a given cart
      */
-    public function getPaymentOption(CartContract $cart): ?PaymentOption;
+    public function getPaymentOption(CartContract $cart, bool $withHidden): ?PaymentOption;
 }

--- a/packages/api/src/Domain/PaymentOptions/Entities/PaymentOption.php
+++ b/packages/api/src/Domain/PaymentOptions/Entities/PaymentOption.php
@@ -28,6 +28,7 @@ class PaymentOption implements Arrayable, Purchasable
         public TaxClassContract $taxClass,
         public ?string $taxReference = null,
         public ?string $option = null,
+        public bool $hidden = false,
         public bool $collect = false,
         public ?array $meta = null,
         public ?Closure $modifyCart = null
@@ -45,6 +46,24 @@ class PaymentOption implements Arrayable, Purchasable
         $this->modifyCart = $closure;
 
         return $this;
+    }
+
+    /**
+     * Hide or show the option.
+     */
+    private function setHidden(bool $hidden = true): self
+    {
+        $this->hidden = $hidden;
+
+        return $this;
+    }
+
+    /**
+     * Check if option is hidden.
+     */
+    public function isHidden(): bool
+    {
+        return $this->hidden;
     }
 
     /**
@@ -232,6 +251,7 @@ class PaymentOption implements Arrayable, Purchasable
             ],
             'currency' => Arr::only($this->getCurrency()->toArray(), ['code', 'name']),
             'default' => $this->isDefault(),
+            'hidden' => $this->isHidden(),
             'meta' => $this->getMeta(),
         ];
     }

--- a/packages/api/src/Domain/PaymentOptions/Facades/PaymentManifest.php
+++ b/packages/api/src/Domain/PaymentOptions/Facades/PaymentManifest.php
@@ -14,9 +14,9 @@ use Lunar\Models\Contracts\Cart as CartContract;
  * @method static PaymentManifest addOptions(Collection $options)
  * @method static PaymentManifest clearOptions()
  * @method static PaymentManifest getOptionUsing(Closure $closure)
- * @method static Collection getOptions(CartContract $cart)
- * @method static ?PaymentOption getOption(CartContract $cart, string $identifier)
- * @method static ?PaymentOption getPaymentOption(CartContract $cart)
+ * @method static Collection<PaymentOption> getOptions(CartContract $cart, bool $withHidden)
+ * @method static ?PaymentOption getOption(CartContract $cart, string $identifier, bool $withHidden)
+ * @method static ?PaymentOption getPaymentOption(CartContract $cart, bool $withHidden)
  *
  * @see \Dystore\Api\Domain\PaymentOptions\Manifests\PaymentManifest
  */

--- a/packages/api/src/Domain/PaymentOptions/Facades/PaymentManifest.php
+++ b/packages/api/src/Domain/PaymentOptions/Facades/PaymentManifest.php
@@ -14,9 +14,9 @@ use Lunar\Models\Contracts\Cart as CartContract;
  * @method static PaymentManifest addOptions(Collection $options)
  * @method static PaymentManifest clearOptions()
  * @method static PaymentManifest getOptionUsing(Closure $closure)
- * @method static Collection<PaymentOption> getOptions(CartContract $cart, bool $withHidden)
- * @method static ?PaymentOption getOption(CartContract $cart, string $identifier, bool $withHidden)
- * @method static ?PaymentOption getPaymentOption(CartContract $cart, bool $withHidden)
+ * @method static Collection<PaymentOption> getOptions(CartContract $cart, bool $withHidden = false)
+ * @method static ?PaymentOption getOption(CartContract $cart, string $identifier, bool $withHidden = true)
+ * @method static ?PaymentOption getPaymentOption(CartContract $cart, bool $withHidden = false)
  *
  * @see \Dystore\Api\Domain\PaymentOptions\Manifests\PaymentManifest
  */

--- a/packages/api/src/Domain/PaymentOptions/Manifests/PaymentManifest.php
+++ b/packages/api/src/Domain/PaymentOptions/Manifests/PaymentManifest.php
@@ -12,9 +12,7 @@ use Lunar\Models\Contracts\Cart as CartContract;
 
 class PaymentManifest implements PaymentManifestContract
 {
-    /**
-     * The collection of available payment options.
-     */
+    /** @var Collection<PaymentOption> */
     public Collection $options;
 
     public ?Closure $getOptionUsing = null;
@@ -77,21 +75,25 @@ class PaymentManifest implements PaymentManifestContract
     /**
      * {@inheritDoc}
      */
-    public function getOptions(CartContract $cart): Collection
+    public function getOptions(CartContract $cart, bool $withHidden = false): Collection
     {
         app(Pipeline::class)
             ->send($cart)
             ->through(
-                app(PaymentModifiers::class)->getModifiers()->toArray()
+                app(PaymentModifiers::class)->getModifiers($withHidden)->toArray()
             )->thenReturn();
 
-        return $this->options;
+        return $this->options
+            ->when(
+                ! $withHidden,
+                fn ($options) => $options->reject(fn ($option) => $option->isHidden())
+            );
     }
 
     /**
      * {@inheritDoc}
      */
-    public function getOption(CartContract $cart, string $identifier): ?PaymentOption
+    public function getOption(CartContract $cart, string $identifier, bool $withHidden = true): ?PaymentOption
     {
         if (filled($this->getOptionUsing)) {
             $paymentOption = ($this->getOptionUsing)($cart, $identifier);
@@ -101,7 +103,7 @@ class PaymentManifest implements PaymentManifestContract
             }
         }
 
-        return $this->getOptions($cart)
+        return $this->getOptions($cart, $withHidden)
             ->where('identifier', $identifier)
             ->first();
     }
@@ -109,12 +111,12 @@ class PaymentManifest implements PaymentManifestContract
     /**
      * {@inheritDoc}
      */
-    public function getPaymentOption(CartContract $cart): ?PaymentOption
+    public function getPaymentOption(CartContract $cart, bool $withHidden = false): ?PaymentOption
     {
         if (! $cart->payment_option) {
             return null;
         }
 
-        return PaymentManifest::getOption($cart, $cart->payment_option);
+        return PaymentManifest::getOption($cart, $cart->payment_option, $withHidden);
     }
 }

--- a/packages/api/src/Domain/Payments/PaymentAdapters/PaymentAdapter.php
+++ b/packages/api/src/Domain/Payments/PaymentAdapters/PaymentAdapter.php
@@ -87,7 +87,10 @@ abstract class PaymentAdapter
                 status: $status,
                 meta: $meta,
             )
-            ->setParentId($parentId)
+            ->when(
+                $parentId,
+                fn (TransactionData $data, int $parentId) => $data->setParentId($parentId),
+            )
             ->setSuccess($success);
 
         return (new CreateTransaction)($data);

--- a/packages/api/src/Domain/Payments/PaymentTypes/OfflinePaymentType.php
+++ b/packages/api/src/Domain/Payments/PaymentTypes/OfflinePaymentType.php
@@ -71,7 +71,7 @@ class OfflinePaymentType extends AbstractPayment
             success: false,
             message: $message,
             orderId: $this->order?->id,
-            paymentType: 'bank-transfer'
+            paymentType: $paymentType,
         );
 
         PaymentAttemptEvent::dispatch($failure);
@@ -82,14 +82,12 @@ class OfflinePaymentType extends AbstractPayment
     /**
      * Create transaction for the payment.
      */
-    protected function createCaptureTransaction(string $paymentType): TransactionContract
+    protected function createCaptureTransaction(string $paymentType = 'offline'): TransactionContract
     {
-        $paymentAdapter = $this->register->get($paymentType);
+        $paymentAdapter = $this->register->get('offline');
 
-        $lastTransaction = (new GetLastOrderTransaction)(
-            order: $this->order,
-            driver: $paymentAdapter->getDriver(),
-        );
+        $lastTransaction = (new GetLastOrderTransaction)(order: $this->order, driver: $paymentAdapter->getDriver())
+            ?? $this->createIntentTransaction($paymentType);
 
         $transaction = $paymentAdapter->createTransaction(
             model: $this->order,
@@ -98,7 +96,23 @@ class OfflinePaymentType extends AbstractPayment
             status: PaymentIntentStatus::SUCCEEDED->value,
             success: true,
             amount: $this->order->total->value,
-            parentId: $lastTransaction->id,
+            meta: $this->data['meta'] ?? [],
+        );
+
+        return $transaction;
+    }
+
+    protected function createIntentTransaction(string $paymentType = 'offline'): TransactionContract
+    {
+        $paymentAdapter = $this->register->get('offline');
+
+        $transaction = $paymentAdapter->createTransaction(
+            model: $this->order,
+            type: TransactionType::INTENT,
+            reference: "{$paymentType}-{$this->order->reference}",
+            status: PaymentIntentStatus::INTENT->value,
+            success: true,
+            amount: $this->order->total->value,
             meta: $this->data['meta'] ?? [],
         );
 

--- a/tests/api/Feature/Domain/Cart/JsonApi/V1/SetPaymentOptionTest.php
+++ b/tests/api/Feature/Domain/Cart/JsonApi/V1/SetPaymentOptionTest.php
@@ -1,13 +1,15 @@
 <?php
 
 use Dystore\Api\Domain\Carts\Models\Cart;
+use Dystore\Api\Domain\PaymentOptions\Entities\PaymentOption;
 use Dystore\Api\Domain\PaymentOptions\Facades\PaymentManifest;
 use Dystore\Tests\Api\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\App;
 use Lunar\Base\CartSessionInterface;
 
-uses(TestCase::class, RefreshDatabase::class);
+uses(TestCase::class, RefreshDatabase::class)
+    ->group('carts', 'payment_options');
 
 beforeEach(function () {
     /** @var TestCase $this */
@@ -44,9 +46,9 @@ test('users can set a payment option to cart', function () {
     ]);
 
     expect($this->cart->fresh()->payment_option)->toBe($data['attributes']['payment_option']);
-})->group('carts', 'payment_options');
+});
 
-it('validates payment option attribute when setting payment option to cart', function () {
+it('validates payment option attribute when setting payment option to a cart', function () {
     /** @var TestCase $this */
     $response = $this
         ->jsonApi()
@@ -63,4 +65,35 @@ it('validates payment option attribute when setting payment option to cart', fun
         'detail' => __('dystore::validations.payments.set_payment_option.payment_option.required'),
         'status' => '422',
     ]);
-})->group('carts', 'payment_options');
+});
+
+it('can set a hidden payment option to a cart', function () {
+    /** @var TestCase $this */
+    $hiddenOption = PaymentManifest::getOptions($this->cart, true)
+        ->firstWhere(fn (PaymentOption $option) => $option->isHidden());
+
+    $this->cartSession->use($this->cart);
+
+    $data = [
+        'type' => 'carts',
+        'attributes' => [
+            'payment_option' => $hiddenOption->identifier,
+        ],
+    ];
+
+    $response = $this
+        ->jsonApi()
+        ->expects('carts')
+        ->withData($data)
+        ->post(serverUrl('/carts/-actions/set-payment-option'));
+
+    $response
+        ->assertSuccessful()
+        ->assertFetchedOne($this->cart);
+
+    $this->assertDatabaseHas($this->cart->getTable(), [
+        'payment_option' => $hiddenOption->identifier,
+    ]);
+
+    expect($this->cart->fresh()->payment_option)->toBe($data['attributes']['payment_option']);
+});

--- a/tests/api/Feature/Domain/Cart/JsonApi/V1/UnsetPaymentOptionTest.php
+++ b/tests/api/Feature/Domain/Cart/JsonApi/V1/UnsetPaymentOptionTest.php
@@ -6,20 +6,21 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\App;
 use Lunar\Base\CartSessionInterface;
 
-uses(TestCase::class, RefreshDatabase::class);
+uses(TestCase::class, RefreshDatabase::class)
+    ->group('carts', 'payment_options');
 
 beforeEach(function () {
     /** @var TestCase $this */
     $this->cartSession = App::make(CartSessionInterface::class);
-
-    $this->cart = Cart::factory()->create([
-        'payment_option' => 'paypal',
-    ]);
 });
 
 test('users can unset a payment option from cart', function () {
     /** @var TestCase $this */
-    $this->cartSession->use($this->cart);
+    $cart = Cart::factory()->create([
+        'payment_option' => 'paypal',
+    ]);
+
+    $this->cartSession->use($cart);
 
     $response = $this
         ->jsonApi()
@@ -31,11 +32,38 @@ test('users can unset a payment option from cart', function () {
 
     $response
         ->assertSuccessful()
-        ->assertFetchedOne($this->cart);
+        ->assertFetchedOne($cart);
 
-    $this->assertDatabaseHas($this->cart->getTable(), [
+    $this->assertDatabaseHas($cart->getTable(), [
         'payment_option' => null,
     ]);
 
-    expect($this->cart->fresh()->payment_option)->toBeNull();
-})->group('carts', 'payment_options');
+    expect($cart->fresh()->payment_option)->toBeNull();
+});
+
+it('can unset a hidden payment option to a cart', function () {
+    /** @var TestCase $this */
+    $cart = Cart::factory()->create([
+        'payment_option' => 'bank-transfer',
+    ]);
+
+    $this->cartSession->use($cart);
+
+    $response = $this
+        ->jsonApi()
+        ->expects('carts')
+        ->withData([
+            'type' => 'carts',
+        ])
+        ->post(serverUrl('/carts/-actions/unset-payment-option'));
+
+    $response
+        ->assertSuccessful()
+        ->assertFetchedOne($cart);
+
+    $this->assertDatabaseHas($cart->getTable(), [
+        'payment_option' => null,
+    ]);
+
+    expect($cart->fresh()->payment_option)->toBeNull();
+});

--- a/tests/api/Feature/Domain/PaymentOptions/JsonApi/V1/ListPaymentOptionsTest.php
+++ b/tests/api/Feature/Domain/PaymentOptions/JsonApi/V1/ListPaymentOptionsTest.php
@@ -8,7 +8,8 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 
-uses(TestCase::class, RefreshDatabase::class);
+uses(TestCase::class, RefreshDatabase::class)
+    ->group('payment_options');
 
 it('can list payment options', function () {
     /** @var TestCase $this */
@@ -42,4 +43,40 @@ it('can list payment options', function () {
         })->toArray()
     );
 
-})->group('payment_options');
+});
+
+it('does not list hidden payment options', function () {
+    /** @var TestCase $this */
+    $response = $this
+        ->jsonApi()
+        ->expects('payment_options')
+        ->get(serverUrl('/payment_options'));
+
+    $response->assertSuccessful();
+
+    $options = PaymentManifest::getOptions(new Cart);
+
+    $response->assertFetchedMany(
+        expected: $options->map(function (PaymentOption $paymentOption) {
+            return [
+                'type' => 'payment_options',
+                'id' => Str::slug($paymentOption->getId()),
+                'attributes' => [
+                    'driver' => $paymentOption->getDriver(),
+                    'name' => $paymentOption->getName(),
+                    'description' => $paymentOption->getDescription(),
+                    'default' => $paymentOption->isDefault(),
+                    'currency' => Arr::only($paymentOption->getCurrency()->toArray(), ['code', 'name']),
+                    'identifier' => $paymentOption->getIdentifier(),
+                    'price' => [
+                        'decimal' => $paymentOption->getPrice()->decimal,
+                        'formatted' => $paymentOption->getPrice()->formatted,
+                    ],
+                ],
+            ];
+        })->toArray(),
+        strict: true
+    );
+
+    $this->assertCount(1, $response->json('data'));
+});

--- a/tests/api/Stubs/Carts/Modifiers/TestPaymentModifier.php
+++ b/tests/api/Stubs/Carts/Modifiers/TestPaymentModifier.php
@@ -27,6 +27,19 @@ class TestPaymentModifier extends PaymentModifier
                 meta: [],
             )
         );
+
+        PaymentManifest::addOption(
+            new PaymentOption(
+                name: 'Hidden Bank Transfer',
+                driver: 'bank-transfer',
+                description: 'Hidden bank transfer payment option',
+                identifier: 'HBT',
+                price: new Price(0, $this->getCurrency($cart), 1),
+                taxClass: $this->getTaxClass(),
+                meta: [],
+                hidden: true,
+            )
+        );
     }
 
     /**


### PR DESCRIPTION
## Description

* Renamed `failedAuthorization` method to `fail` in `OfflinePaymentType`
* Added handling of hidden payment options (useful for implementing manual bank transfer payment option etc.)
* Fixed offline payment type authorization

## Type of Change

-   [x] Bug fix
-   [x] New feature
-   [ ] Breaking change

## Testing

-   [x] Automated tests added
