### PR TITLE
Fix: Create transaction before updating order status

### DIFF
--- a/packages/api/src/Domain/Payments/PaymentTypes/OfflinePaymentType.php
+++ b/packages/api/src/Domain/Payments/PaymentTypes/OfflinePaymentType.php
@@ -44,13 +44,13 @@ class OfflinePaymentType extends AbstractPayment
 
         $status = $this->data['authorized'] ?? null;
 
+        $this->createCaptureTransaction($paymentType);
+
         $this->order->update([
             'status' => $status ?? $this->config['authorized'] ?? 'payment-received',
             'meta' => $meta,
             'placed_at' => Carbon::now(),
         ]);
-
-        $this->createCaptureTransaction($paymentType);
 
         $authorization = new PaymentAuthorize(
             success: true,


### PR DESCRIPTION
* Because transaction data come in handy in "order paid" notifications