### PR TITLE
Fix: Fix products N+1 queries

### DIFF
--- a/packages/api/src/Domain/JsonApi/Eloquent/Fields/AttributeData.php
+++ b/packages/api/src/Domain/JsonApi/Eloquent/Fields/AttributeData.php
@@ -132,6 +132,10 @@ class AttributeData extends Attribute
             return Hash::cast([]);
         }
 
+        if ($model->relationLoaded('productType') && $model->productType->relationLoaded('mappedAttributes')) {
+            $model->setRelation('attributes', $model->productType->mappedAttributes);
+        }
+
         if (is_iterable($model->attributes) && count($model->attributes) > 0) {
             $attributes = $model->attributes
                 ->where('attribute_type', $model->getMorphClass())

--- a/packages/api/src/Domain/Products/JsonApi/V1/ProductSchema.php
+++ b/packages/api/src/Domain/Products/JsonApi/V1/ProductSchema.php
@@ -64,6 +64,8 @@ class ProductSchema extends Schema
             'productType.mappedAttributes',
             'productType.mappedAttributes.attributeGroup',
 
+            'variants',
+
             ...parent::with(),
         ];
     }


### PR DESCRIPTION
* Use product type mapped attributes if already loaded
* Always load variants (used to determine product availability)