### PR TITLE
Stripe feat: Check eshop ID before processing stripe webhooks

### DIFF
--- a/packages/api/src/ApiServiceProvider.php
+++ b/packages/api/src/ApiServiceProvider.php
@@ -5,6 +5,8 @@ namespace Dystore\Api;
 use Dystore\Api\Api as DystoreApi;
 use Dystore\Api\Domain\Carts\Actions\CheckoutCart;
 use Dystore\Api\Domain\Carts\Actions\CreateUserFromCart;
+use Dystore\Api\Domain\Payments\Contracts\PaymentIntent as PaymentIntentContract;
+use Dystore\Api\Domain\Payments\Data\PaymentIntent;
 use Dystore\Api\Domain\Users\Actions\CreateUser;
 use Dystore\Api\Domain\Users\Actions\RegisterUser;
 use Dystore\Api\Facades\Api;
@@ -75,6 +77,11 @@ class ApiServiceProvider extends ServiceProvider
         $this->app->singleton(
             \Lunar\Base\StorefrontSessionInterface::class,
             fn (Application $app) => $app->make(\Dystore\Api\Domain\Storefront\Managers\StorefrontSessionManager::class),
+        );
+
+        $this->app->bind(
+            PaymentIntentContract::class,
+            PaymentIntent::class,
         );
     }
 

--- a/packages/stripe/config/stripe-webhooks.php
+++ b/packages/stripe/config/stripe-webhooks.php
@@ -41,7 +41,7 @@ return [
     /**
      * This class determines if the webhook call should be stored and processed.
      */
-    'profile' => \Spatie\StripeWebhooks\StripeWebhookProfile::class,
+    'profile' => \Dystore\Stripe\Jobs\Webhooks\WebhookProfile::class,
 
     /*
      * Specify a connection and or a queue to process the webhooks

--- a/packages/stripe/config/stripe.php
+++ b/packages/stripe/config/stripe.php
@@ -23,11 +23,14 @@ return [
     */
     'type' => 'stripe',
 
-    /**
-     * Automatic payment methods
-     *
-     * Enable automatic payment methods.
-     */
+    /*
+    |--------------------------------------------------------------------------
+    | Automatic payment methods
+    |--------------------------------------------------------------------------
+    |
+    | Enable or disable automatic payment methods for payment intents.
+    |
+    */
     'automatic_payment_methods' => true,
 
     /*
@@ -40,4 +43,16 @@ return [
     |
     */
     'eshop_id' => env('STRIPE_ESHOP_ID', env('APP_NAME')),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Eshop ids to handle
+    |--------------------------------------------------------------------------
+    |
+    | If set to ['*'] : All webhooks will be handled
+    | If set to ['Eshop'] : Just webhooks with eshop_id = 'Eshop' will be handled
+    | If set to [] : No webhooks will be handled
+    |
+    */
+    'handle_eshop_ids' => ['*'],
 ];

--- a/packages/stripe/config/stripe.php
+++ b/packages/stripe/config/stripe.php
@@ -29,4 +29,15 @@ return [
      * Enable automatic payment methods.
      */
     'automatic_payment_methods' => true,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Stripe eshop identifier
+    |--------------------------------------------------------------------------
+    |
+    | This key serves as an eship identification and is passed to
+    | payment intent metadata during its creation.
+    |
+    */
+    'eshop_id' => env('STRIPE_ESHOP_ID', env('APP_NAME')),
 ];

--- a/packages/stripe/src/Jobs/Webhooks/WebhookHandler.php
+++ b/packages/stripe/src/Jobs/Webhooks/WebhookHandler.php
@@ -6,7 +6,6 @@ use Dystore\Api\Domain\Orders\Actions\FindOrderByCartIntent;
 use Dystore\Api\Domain\Orders\Actions\FindOrderByIntent;
 use Dystore\Api\Domain\Orders\Actions\FindOrderByTransaction;
 use Dystore\Api\Domain\Payments\Contracts\PaymentIntent as PaymentIntentContract;
-use Dystore\Api\Domain\Payments\Data\PaymentIntent;
 use Dystore\Api\Domain\Payments\PaymentAdapters\PaymentAdapter;
 use Dystore\Api\Domain\Payments\PaymentAdapters\PaymentAdaptersRegister;
 use Illuminate\Bus\Queueable;
@@ -23,7 +22,9 @@ use Throwable;
 
 abstract class WebhookHandler implements ShouldQueue
 {
-    use InteractsWithQueue, Queueable, SerializesModels;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
 
     public WebhookCall $webhookCall;
 
@@ -57,7 +58,9 @@ abstract class WebhookHandler implements ShouldQueue
      */
     protected function getPaymentIntentFromEvent(Event $event): PaymentIntentContract
     {
-        return new PaymentIntent(intent: $event->data->object);
+        return App::make(PaymentIntentContract::class, [
+            'intent' => $event->data->object,
+        ]);
     }
 
     /**

--- a/packages/stripe/src/Jobs/Webhooks/WebhookProfile.php
+++ b/packages/stripe/src/Jobs/Webhooks/WebhookProfile.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Dystore\Stripe\Jobs\Webhooks;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Config;
+use Spatie\StripeWebhooks\StripeWebhookProfile;
+use Spatie\WebhookClient\Models\WebhookCall;
+
+class WebhookProfile extends StripeWebhookProfile
+{
+    public function shouldProcess(Request $request): bool
+    {
+        if (! $this->checkValidEshopId($request)) {
+            return false;
+        }
+
+        if ($this->checkWebhookCallExists($request)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    protected function checkWebhookCallExists(Request $request): bool
+    {
+        return WebhookCall::where('name', 'stripe')->where('payload->id', $request->get('id'))->exists();
+    }
+
+    protected function checkValidEshopId(Request $request): bool
+    {
+        if (in_array('*', Config::get('dystore.stripe.handle_eshop_ids'))) {
+            return true;
+        }
+
+        if (in_array($this->getEshopIdFromRequest($request), Config::get('dystore.stripe.handle_eshop_ids'))) {
+            return true;
+        }
+
+        return false;
+    }
+
+    protected function getEshopIdFromRequest(Request $request): ?string
+    {
+        return $request->input('data.object.metadata.eshop_id', null);
+    }
+}

--- a/packages/stripe/src/StripePaymentAdapter.php
+++ b/packages/stripe/src/StripePaymentAdapter.php
@@ -67,8 +67,18 @@ class StripePaymentAdapter extends PaymentAdapter
     {
         $cart = $this->updateCartMeta($cart, $meta);
 
+        $opts = [
+            'metadata' => [
+                'eshop' => env('APP_NAME'),
+                ...$meta,
+            ],
+        ];
+
         /** @var \Stripe\PaymentIntent $paymentIntent */
-        $stripePaymentIntent = $this->stripeManager->createIntent($cart->calculate());
+        $stripePaymentIntent = $this->stripeManager->createIntent(
+            cart: $cart->calculate(),
+            opts: $opts,
+        );
 
         $paymentIntent = new PaymentIntent(
             intent: $stripePaymentIntent,

--- a/packages/stripe/src/StripePaymentAdapter.php
+++ b/packages/stripe/src/StripePaymentAdapter.php
@@ -69,7 +69,7 @@ class StripePaymentAdapter extends PaymentAdapter
 
         $opts = [
             'metadata' => [
-                'eshop' => env('APP_NAME'),
+                'eshop_id' => Config::get('dystore.stripe.eshop_id'),
                 ...$meta,
             ],
         ];

--- a/tests/stripe/Feature/CreatePaymentIntentTest.php
+++ b/tests/stripe/Feature/CreatePaymentIntentTest.php
@@ -56,7 +56,7 @@ test('can create a payment intent', function (string $paymentMethod) {
 
 })->with(['stripe']);
 
-it('creates a transaction when creating a payement intent', function (string $paymentMethod) {
+it('creates a transaction when creating a payment intent', function (string $paymentMethod) {
     /** @var TestCase $this */
     $url = URL::signedRoute(
         name: 'v1.orders.createPaymentIntent',

--- a/tests/stripe/Feature/HandleStripeWebhookTest.php
+++ b/tests/stripe/Feature/HandleStripeWebhookTest.php
@@ -2,17 +2,17 @@
 
 use Dystore\Api\Domain\Carts\Events\CartCreated;
 use Dystore\Api\Domain\Carts\Models\Cart;
-use Dystore\Api\Domain\Orders\Events\OrderPaymentCanceled;
-use Dystore\Api\Domain\Orders\Events\OrderPaymentFailed;
-use Dystore\Api\Domain\Orders\Events\OrderPaymentSuccessful;
+use Dystore\Stripe\Jobs\Webhooks\HandleOtherEvent;
+use Dystore\Stripe\Jobs\Webhooks\HandlePaymentIntentCanceled;
+use Dystore\Stripe\Jobs\Webhooks\HandlePaymentIntentFailed;
 use Dystore\Stripe\Jobs\Webhooks\HandlePaymentIntentSucceeded;
 use Dystore\Stripe\StripePaymentAdapter;
 use Dystore\Tests\Stripe\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Queue;
 use Lunar\Stripe\Concerns\ConstructsWebhookEvent;
 use Stripe\PaymentIntent;
 
@@ -52,8 +52,7 @@ beforeEach(function () {
 
 it('can handle payment_intent.succeeded event', function () {
     /** @var TestCase $this */
-    Event::fake();
-    Queue::fake();
+    Bus::fake([HandlePaymentIntentSucceeded::class]);
 
     $data = json_decode(file_get_contents(__DIR__.'/../Stubs/Stripe/payment_intent.succeeded.json'), true);
 
@@ -77,14 +76,12 @@ it('can handle payment_intent.succeeded event', function () {
 
     $response->assertSuccessful();
 
-    // Queue::assertPushed(HandlePaymentIntentSucceeded::class);
-    // Event::assertDispatched(OrderPaymentSuccessful::class);
+    Bus::assertDispatched(HandlePaymentIntentSucceeded::class);
 })->group('webhooks');
 
 it('can handle payment_intent.canceled event', function () {
     /** @var TestCase $this */
-    Event::fake();
-    Queue::fake();
+    Bus::fake([HandlePaymentIntentCanceled::class]);
 
     $data = json_decode(file_get_contents(__DIR__.'/../Stubs/Stripe/payment_intent.canceled.json'), true);
 
@@ -100,13 +97,12 @@ it('can handle payment_intent.canceled event', function () {
 
     $response->assertSuccessful();
 
-    // Event::assertDispatched(OrderPaymentCanceled::class);
+    Bus::assertDispatched(HandlePaymentIntentCanceled::class);
 })->group('webhooks');
 
 it('can handle payment_intent.failed event', function () {
     /** @var TestCase $this */
-    Event::fake();
-    Queue::fake();
+    Bus::fake([HandlePaymentIntentFailed::class]);
 
     $data = json_decode(file_get_contents(__DIR__.'/../Stubs/Stripe/payment_intent.payment_failed.json'), true);
 
@@ -122,13 +118,12 @@ it('can handle payment_intent.failed event', function () {
 
     $response->assertSuccessful();
 
-    // Event::assertDispatched(OrderPaymentFailed::class);
+    Bus::assertDispatched(HandlePaymentIntentFailed::class);
 })->group('webhooks');
 
 it('can handle any other event', function () {
     /** @var TestCase $this */
-    Event::fake();
-    Queue::fake();
+    Bus::fake([HandleOtherEvent::class]);
 
     $data = json_decode(file_get_contents(__DIR__.'/../Stubs/Stripe/charge.succeeded.json'), true);
 
@@ -143,4 +138,26 @@ it('can handle any other event', function () {
         );
 
     $response->assertSuccessful();
+
+    Bus::assertDispatched(HandleOtherEvent::class);
+})->group('webhooks');
+
+it('does not handle events with incorrect eshop_id if configured', function () {
+    /** @var TestCase $this */
+    Bus::fake([HandlePaymentIntentSucceeded::class]);
+
+    Config::set('dystore.stripe.handle_eshop_ids', ['Fake Store']);
+
+    $data = json_decode(file_get_contents(__DIR__.'/../Stubs/Stripe/payment_intent.succeeded.json'), true);
+
+    $response = $this
+        ->post(
+            '/stripe/webhook',
+            $data,
+            ['Stripe-Signature' => $this->determineStripeSignature($data)],
+        );
+
+    $response->assertSuccessful();
+
+    Bus::assertNotDispatched(HandlePaymentIntentSucceeded::class);
 })->group('webhooks');

--- a/tests/stripe/Stubs/Stripe/charge.succeeded.json
+++ b/tests/stripe/Stubs/Stripe/charge.succeeded.json
@@ -1,139 +1,141 @@
 {
-    "id": "evt_3OEUWGEZ3kRHbqdV0QKRSEUF",
-    "object": "event",
-    "api_version": "2020-08-27",
-    "created": 1700475530,
-    "data": {
-        "object": {
-            "id": "ch_3OEUWGEZ3kRHbqdV0exudprO",
-            "object": "charge",
-            "amount": 16400,
-            "amount_captured": 16400,
-            "amount_refunded": 0,
-            "application": null,
-            "application_fee": null,
-            "application_fee_amount": null,
-            "balance_transaction": "txn_3OEUWG1234HbqdV0CDvlM0E",
-            "billing_details": {
-                "address": {
-                    "city": null,
-                    "country": "CZ",
-                    "line1": null,
-                    "line2": null,
-                    "postal_code": null,
-                    "state": null
-                },
-                "email": null,
-                "name": "never",
-                "phone": null
-            },
-            "calculated_statement_descriptor": "RANDOM",
-            "captured": true,
-            "created": 1700475529,
-            "currency": "czk",
-            "customer": null,
-            "description": null,
-            "destination": null,
-            "dispute": null,
-            "disputed": false,
-            "failure_balance_transaction": null,
-            "failure_code": null,
-            "failure_message": null,
-            "fraud_details": {},
-            "invoice": null,
-            "livemode": true,
-            "metadata": {},
-            "on_behalf_of": null,
-            "order": null,
-            "outcome": {
-                "network_status": "approved_by_network",
-                "reason": null,
-                "risk_level": "normal",
-                "seller_message": "Payment complete.",
-                "type": "authorized"
-            },
-            "paid": true,
-            "payment_intent": "pi_3OEUWGEZ3kRHbqdV0Ux8YRbB",
-            "payment_method": "pm_1OEUZ2EZ3kRHbqdVCUZqHxH5",
-            "payment_method_details": {
-                "card": {
-                    "amount_authorized": 16400,
-                    "brand": "visa",
-                    "checks": {
-                        "address_line1_check": null,
-                        "address_postal_code_check": null,
-                        "cvc_check": "pass"
-                    },
-                    "country": "CZ",
-                    "exp_month": 3,
-                    "exp_year": 2028,
-                    "extended_authorization": {
-                        "status": "disabled"
-                    },
-                    "fingerprint": "8yld7yPLP3cePTcH",
-                    "funding": "debit",
-                    "incremental_authorization": {
-                        "status": "unavailable"
-                    },
-                    "installments": null,
-                    "last4": "9043",
-                    "mandate": null,
-                    "multicapture": {
-                        "status": "unavailable"
-                    },
-                    "network": "visa",
-                    "network_token": {
-                        "used": false
-                    },
-                    "overcapture": {
-                        "maximum_amount_capturable": 16400,
-                        "status": "unavailable"
-                    },
-                    "three_d_secure": null,
-                    "wallet": null
-                },
-                "type": "card"
-            },
-            "receipt_email": null,
-            "receipt_number": null,
-            "receipt_url": "https://pay.stripe.com/receipts/payment/random",
-            "refunded": false,
-            "refunds": {
-                "object": "list",
-                "data": [],
-                "has_more": false,
-                "total_count": 0,
-                "url": "/v1/charges/ch_1234GEZ3kRHbqdV0exudprO/refunds"
-            },
-            "review": null,
-            "shipping": {
-                "address": {
-                    "city": "City",
-                    "country": "CZ",
-                    "line1": "Random address",
-                    "line2": null,
-                    "postal_code": "111 22",
-                    "state": null
-                },
-                "carrier": null,
-                "name": "Random Guy",
-                "phone": null,
-                "tracking_number": null
-            },
-            "source": null,
-            "source_transfer": null,
-            "statement_descriptor": null,
-            "statement_descriptor_suffix": null,
-            "status": "succeeded",
-            "transfer_data": null,
-            "transfer_group": null
-        }
-    },
-    "livemode": true,
-    "pending_webhooks": 1,
-    "request": {
-        "id": "req_x1KXFtO7azV9ur",
-        "idempotency_key": "0991a6e0-9f44-49f5-a261-f9324add9718"
-    },
-    "type": "charge.succeeded"
+  "id": "evt_3OEUWGEZ3kRHbqdV0QKRSEUF",
+  "object": "event",
+  "api_version": "2020-08-27",
+  "created": 1700475530,
+  "data": {
+    "object": {
+      "id": "ch_3OEUWGEZ3kRHbqdV0exudprO",
+      "object": "charge",
+      "amount": 16400,
+      "amount_captured": 16400,
+      "amount_refunded": 0,
+      "application": null,
+      "application_fee": null,
+      "application_fee_amount": null,
+      "balance_transaction": "txn_3OEUWG1234HbqdV0CDvlM0E",
+      "billing_details": {
+        "address": {
+          "city": null,
+          "country": "CZ",
+          "line1": null,
+          "line2": null,
+          "postal_code": null,
+          "state": null
+        },
+        "email": null,
+        "name": "never",
+        "phone": null
+      },
+      "calculated_statement_descriptor": "RANDOM",
+      "captured": true,
+      "created": 1700475529,
+      "currency": "czk",
+      "customer": null,
+      "description": null,
+      "destination": null,
+      "dispute": null,
+      "disputed": false,
+      "failure_balance_transaction": null,
+      "failure_code": null,
+      "failure_message": null,
+      "fraud_details": {},
+      "invoice": null,
+      "livemode": true,
+      "metadata": {
+        "eshop_id": "Dystore"
+      },
+      "on_behalf_of": null,
+      "order": null,
+      "outcome": {
+        "network_status": "approved_by_network",
+        "reason": null,
+        "risk_level": "normal",
+        "seller_message": "Payment complete.",
+        "type": "authorized"
+      },
+      "paid": true,
+      "payment_intent": "pi_3OEUWGEZ3kRHbqdV0Ux8YRbB",
+      "payment_method": "pm_1OEUZ2EZ3kRHbqdVCUZqHxH5",
+      "payment_method_details": {
+        "card": {
+          "amount_authorized": 16400,
+          "brand": "visa",
+          "checks": {
+            "address_line1_check": null,
+            "address_postal_code_check": null,
+            "cvc_check": "pass"
+          },
+          "country": "CZ",
+          "exp_month": 3,
+          "exp_year": 2028,
+          "extended_authorization": {
+            "status": "disabled"
+          },
+          "fingerprint": "8yld7yPLP3cePTcH",
+          "funding": "debit",
+          "incremental_authorization": {
+            "status": "unavailable"
+          },
+          "installments": null,
+          "last4": "9043",
+          "mandate": null,
+          "multicapture": {
+            "status": "unavailable"
+          },
+          "network": "visa",
+          "network_token": {
+            "used": false
+          },
+          "overcapture": {
+            "maximum_amount_capturable": 16400,
+            "status": "unavailable"
+          },
+          "three_d_secure": null,
+          "wallet": null
+        },
+        "type": "card"
+      },
+      "receipt_email": null,
+      "receipt_number": null,
+      "receipt_url": "https://pay.stripe.com/receipts/payment/random",
+      "refunded": false,
+      "refunds": {
+        "object": "list",
+        "data": [],
+        "has_more": false,
+        "total_count": 0,
+        "url": "/v1/charges/ch_1234GEZ3kRHbqdV0exudprO/refunds"
+      },
+      "review": null,
+      "shipping": {
+        "address": {
+          "city": "City",
+          "country": "CZ",
+          "line1": "Random address",
+          "line2": null,
+          "postal_code": "111 22",
+          "state": null
+        },
+        "carrier": null,
+        "name": "Random Guy",
+        "phone": null,
+        "tracking_number": null
+      },
+      "source": null,
+      "source_transfer": null,
+      "statement_descriptor": null,
+      "statement_descriptor_suffix": null,
+      "status": "succeeded",
+      "transfer_data": null,
+      "transfer_group": null
+    }
+  },
+  "livemode": true,
+  "pending_webhooks": 1,
+  "request": {
+    "id": "req_x1KXFtO7azV9ur",
+    "idempotency_key": "0991a6e0-9f44-49f5-a261-f9324add9718"
+  },
+  "type": "charge.succeeded"
 }

--- a/tests/stripe/Stubs/Stripe/payment_intent.succeeded.json
+++ b/tests/stripe/Stubs/Stripe/payment_intent.succeeded.json
@@ -1,196 +1,198 @@
 {
-    "id": "evt_3N8cfsHpEETAPIl80GgDDDRF",
-    "object": "event",
-    "api_version": "2016-07-06",
-    "created": 1684300401,
-    "data": {
-        "object": {
-            "id": "pi_3N8cfsHpEETAPIl80N89iHWo",
-            "object": "payment_intent",
-            "allowed_source_types": ["card"],
+  "id": "evt_3N8cfsHpEETAPIl80GgDDDRF",
+  "object": "event",
+  "api_version": "2016-07-06",
+  "created": 1684300401,
+  "data": {
+    "object": {
+      "id": "pi_3N8cfsHpEETAPIl80N89iHWo",
+      "object": "payment_intent",
+      "allowed_source_types": ["card"],
+      "amount": 2000,
+      "amount_capturable": 0,
+      "amount_details": {
+        "tip": []
+      },
+      "amount_received": 2000,
+      "application": null,
+      "application_fee_amount": null,
+      "automatic_payment_methods": null,
+      "canceled_at": null,
+      "cancellation_reason": null,
+      "capture_method": "automatic",
+      "charges": {
+        "object": "list",
+        "data": [
+          {
+            "id": "ch_3N8cfsHpEETAPIl805407YXh",
+            "object": "charge",
             "amount": 2000,
-            "amount_capturable": 0,
-            "amount_details": {
-                "tip": []
-            },
-            "amount_received": 2000,
+            "amount_captured": 2000,
+            "amount_refunded": 0,
             "application": null,
+            "application_fee": null,
             "application_fee_amount": null,
-            "automatic_payment_methods": null,
-            "canceled_at": null,
-            "cancellation_reason": null,
-            "capture_method": "automatic",
-            "charges": {
-                "object": "list",
-                "data": [
-                    {
-                        "id": "ch_3N8cfsHpEETAPIl805407YXh",
-                        "object": "charge",
-                        "amount": 2000,
-                        "amount_captured": 2000,
-                        "amount_refunded": 0,
-                        "application": null,
-                        "application_fee": null,
-                        "application_fee_amount": null,
-                        "balance_transaction": "txn_3N8cfsHpEETAPIl80eyDr5bH",
-                        "billing_details": {
-                            "address": {
-                                "city": null,
-                                "country": null,
-                                "line1": null,
-                                "line2": null,
-                                "postal_code": null,
-                                "state": null
-                            },
-                            "email": null,
-                            "name": null,
-                            "phone": null
-                        },
-                        "calculated_statement_descriptor": "DP TASTATUR AUSST. UG",
-                        "captured": true,
-                        "created": 1684300400,
-                        "currency": "usd",
-                        "customer": null,
-                        "description": "(created by Stripe CLI)",
-                        "destination": null,
-                        "dispute": null,
-                        "disputed": false,
-                        "failure_balance_transaction": null,
-                        "failure_code": null,
-                        "failure_message": null,
-                        "fraud_details": [],
-                        "invoice": null,
-                        "livemode": false,
-                        "metadata": [],
-                        "on_behalf_of": null,
-                        "order": null,
-                        "outcome": {
-                            "network_status": "approved_by_network",
-                            "reason": null,
-                            "risk_level": "normal",
-                            "risk_score": 8,
-                            "seller_message": "Payment complete.",
-                            "type": "authorized"
-                        },
-                        "paid": true,
-                        "payment_intent": "pi_3N8cfsHpEETAPIl80N89iHWo",
-                        "payment_method": "pm_1N8cfsHpEETAPIl8xFpNcMom",
-                        "payment_method_details": {
-                            "card": {
-                                "brand": "visa",
-                                "checks": {
-                                    "address_line1_check": null,
-                                    "address_postal_code_check": null,
-                                    "cvc_check": null
-                                },
-                                "country": "US",
-                                "exp_month": 5,
-                                "exp_year": 2024,
-                                "fingerprint": "TTTJjzgFUKHVMKkw",
-                                "funding": "credit",
-                                "installments": null,
-                                "last4": "4242",
-                                "mandate": null,
-                                "network": "visa",
-                                "network_token": {
-                                    "used": false
-                                },
-                                "three_d_secure": null,
-                                "wallet": null
-                            },
-                            "type": "card"
-                        },
-                        "receipt_email": null,
-                        "receipt_number": null,
-                        "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xOTZpSWNIcEVFVEFQSWw4KPHEkaMGMgYvfBMaNLU6LBYHzKPdQ-tn75m0mcLoW0FHQStgJzRzPdWSeK3Kgq1270xdRi0v_TLKLRtg",
-                        "refunded": false,
-                        "refunds": {
-                            "object": "list",
-                            "data": [],
-                            "has_more": false,
-                            "total_count": 0,
-                            "url": "/v1/charges/ch_3N8cfsHpEETAPIl805407YXh/refunds"
-                        },
-                        "review": null,
-                        "shipping": {
-                            "address": {
-                                "city": "San Francisco",
-                                "country": "US",
-                                "line1": "510 Townsend St",
-                                "line2": null,
-                                "postal_code": "94103",
-                                "state": "CA"
-                            },
-                            "carrier": null,
-                            "name": "Jenny Rosen",
-                            "phone": null,
-                            "tracking_number": null
-                        },
-                        "source": null,
-                        "source_transfer": null,
-                        "statement_descriptor": null,
-                        "statement_descriptor_suffix": null,
-                        "status": "succeeded",
-                        "transfer_data": null,
-                        "transfer_group": null
-                    }
-                ],
-                "has_more": false,
-                "total_count": 1,
-                "url": "/v1/charges?payment_intent=pi_3N8cfsHpEETAPIl80N89iHWo"
+            "balance_transaction": "txn_3N8cfsHpEETAPIl80eyDr5bH",
+            "billing_details": {
+              "address": {
+                "city": null,
+                "country": null,
+                "line1": null,
+                "line2": null,
+                "postal_code": null,
+                "state": null
+              },
+              "email": null,
+              "name": null,
+              "phone": null
             },
-            "client_secret": "pi_3N8cfsHpEETAPIl80N89iHWo_secret_Et9RkWuJQiaOcCauqsAcLkh1I",
-            "confirmation_method": "automatic",
+            "calculated_statement_descriptor": "DP TASTATUR AUSST. UG",
+            "captured": true,
             "created": 1684300400,
             "currency": "usd",
             "customer": null,
             "description": "(created by Stripe CLI)",
+            "destination": null,
+            "dispute": null,
+            "disputed": false,
+            "failure_balance_transaction": null,
+            "failure_code": null,
+            "failure_message": null,
+            "fraud_details": [],
             "invoice": null,
-            "last_payment_error": null,
-            "latest_charge": "ch_3N8cfsHpEETAPIl805407YXh",
             "livemode": false,
             "metadata": [],
-            "next_action": null,
-            "next_source_action": null,
             "on_behalf_of": null,
-            "payment_method": "pm_1N8cfsHpEETAPIl8xFpNcMom",
-            "payment_method_options": {
-                "card": {
-                    "installments": null,
-                    "mandate_options": null,
-                    "network": null,
-                    "request_three_d_secure": "automatic"
-                }
+            "order": null,
+            "outcome": {
+              "network_status": "approved_by_network",
+              "reason": null,
+              "risk_level": "normal",
+              "risk_score": 8,
+              "seller_message": "Payment complete.",
+              "type": "authorized"
             },
-            "payment_method_types": ["card"],
-            "processing": null,
-            "receipt_email": null,
-            "review": null,
-            "setup_future_usage": null,
-            "shipping": {
-                "address": {
-                    "city": "San Francisco",
-                    "country": "US",
-                    "line1": "510 Townsend St",
-                    "line2": null,
-                    "postal_code": "94103",
-                    "state": "CA"
+            "paid": true,
+            "payment_intent": "pi_3N8cfsHpEETAPIl80N89iHWo",
+            "payment_method": "pm_1N8cfsHpEETAPIl8xFpNcMom",
+            "payment_method_details": {
+              "card": {
+                "brand": "visa",
+                "checks": {
+                  "address_line1_check": null,
+                  "address_postal_code_check": null,
+                  "cvc_check": null
                 },
-                "carrier": null,
-                "name": "Jenny Rosen",
-                "phone": null,
-                "tracking_number": null
+                "country": "US",
+                "exp_month": 5,
+                "exp_year": 2024,
+                "fingerprint": "TTTJjzgFUKHVMKkw",
+                "funding": "credit",
+                "installments": null,
+                "last4": "4242",
+                "mandate": null,
+                "network": "visa",
+                "network_token": {
+                  "used": false
+                },
+                "three_d_secure": null,
+                "wallet": null
+              },
+              "type": "card"
+            },
+            "receipt_email": null,
+            "receipt_number": null,
+            "receipt_url": "https://pay.stripe.com/receipts/payment/CAcaFwoVYWNjdF8xOTZpSWNIcEVFVEFQSWw4KPHEkaMGMgYvfBMaNLU6LBYHzKPdQ-tn75m0mcLoW0FHQStgJzRzPdWSeK3Kgq1270xdRi0v_TLKLRtg",
+            "refunded": false,
+            "refunds": {
+              "object": "list",
+              "data": [],
+              "has_more": false,
+              "total_count": 0,
+              "url": "/v1/charges/ch_3N8cfsHpEETAPIl805407YXh/refunds"
+            },
+            "review": null,
+            "shipping": {
+              "address": {
+                "city": "San Francisco",
+                "country": "US",
+                "line1": "510 Townsend St",
+                "line2": null,
+                "postal_code": "94103",
+                "state": "CA"
+              },
+              "carrier": null,
+              "name": "Jenny Rosen",
+              "phone": null,
+              "tracking_number": null
             },
             "source": null,
+            "source_transfer": null,
             "statement_descriptor": null,
             "statement_descriptor_suffix": null,
             "status": "succeeded",
             "transfer_data": null,
             "transfer_group": null
+          }
+        ],
+        "has_more": false,
+        "total_count": 1,
+        "url": "/v1/charges?payment_intent=pi_3N8cfsHpEETAPIl80N89iHWo"
+      },
+      "client_secret": "pi_3N8cfsHpEETAPIl80N89iHWo_secret_Et9RkWuJQiaOcCauqsAcLkh1I",
+      "confirmation_method": "automatic",
+      "created": 1684300400,
+      "currency": "usd",
+      "customer": null,
+      "description": "(created by Stripe CLI)",
+      "invoice": null,
+      "last_payment_error": null,
+      "latest_charge": "ch_3N8cfsHpEETAPIl805407YXh",
+      "livemode": false,
+      "metadata": {
+        "eshop_id": "Dystore"
+      },
+      "next_action": null,
+      "next_source_action": null,
+      "on_behalf_of": null,
+      "payment_method": "pm_1N8cfsHpEETAPIl8xFpNcMom",
+      "payment_method_options": {
+        "card": {
+          "installments": null,
+          "mandate_options": null,
+          "network": null,
+          "request_three_d_secure": "automatic"
         }
-    },
-    "livemode": false,
-    "pending_webhooks": 2,
-    "request": "req_bZcr9zi78q4tBg",
-    "type": "payment_intent.succeeded"
+      },
+      "payment_method_types": ["card"],
+      "processing": null,
+      "receipt_email": null,
+      "review": null,
+      "setup_future_usage": null,
+      "shipping": {
+        "address": {
+          "city": "San Francisco",
+          "country": "US",
+          "line1": "510 Townsend St",
+          "line2": null,
+          "postal_code": "94103",
+          "state": "CA"
+        },
+        "carrier": null,
+        "name": "Jenny Rosen",
+        "phone": null,
+        "tracking_number": null
+      },
+      "source": null,
+      "statement_descriptor": null,
+      "statement_descriptor_suffix": null,
+      "status": "succeeded",
+      "transfer_data": null,
+      "transfer_group": null
+    }
+  },
+  "livemode": false,
+  "pending_webhooks": 2,
+  "request": "req_bZcr9zi78q4tBg",
+  "type": "payment_intent.succeeded"
 }

--- a/tests/stripe/TestCase.php
+++ b/tests/stripe/TestCase.php
@@ -127,6 +127,8 @@ abstract class TestCase extends OrchestraTestCase
                 ],
             ]);
             $config->set('dystore.stripe.automatic_payment_methods', false);
+            $config->set('dystore.stripe.eshop_id', 'Dystore');
+            $config->set('dystore.stripe.handle_eshop_ids', ['*']);
 
             // Default payment driver
             $config->set('lunar.payments.default', 'stripe');
@@ -139,7 +141,16 @@ abstract class TestCase extends OrchestraTestCase
 
             // Stripe webhooks
             $config->set('stripe-webhooks.verify_signature', false);
-            $config->set('stripe-webhooks.connection', false);
+            $config->set('stripe-webhooks.connection', 'sync');
+            $config->set('stripe-webhooks.default_job', \Dystore\Stripe\Jobs\Webhooks\HandleOtherEvent::class);
+            $config->set('stripe-webhooks.profile', \Dystore\Stripe\Jobs\Webhooks\WebhookProfile::class);
+            $config->set('stripe-webhooks.jobs', [
+                'payment_intent_created' => \Dystore\Stripe\Jobs\Webhooks\HandlePaymentIntentCreated::class,
+                'payment_intent_succeeded' => \Dystore\Stripe\Jobs\Webhooks\HandlePaymentIntentSucceeded::class,
+                'payment_intent_payment_failed' => \Dystore\Stripe\Jobs\Webhooks\HandlePaymentIntentFailed::class,
+                'payment_intent_canceled' => \Dystore\Stripe\Jobs\Webhooks\HandlePaymentIntentCanceled::class,
+                'payment_intent_payment_failed' => \Dystore\Stripe\Jobs\Webhooks\HandlePaymentIntentFailed::class,
+            ]);
         });
 
     }


### PR DESCRIPTION
## Description

It is now possible to set `eshop_id` which will be passed when creating Stripe payment intent.

Configuration changes in `dystore/stripe.php`:

```php
    /*
    |--------------------------------------------------------------------------
    | Stripe eshop identifier
    |--------------------------------------------------------------------------
    |
    | This key serves as an eship identification and is passed to
    | payment intent metadata during its creation.
    |
    */
    'eshop_id' => env('STRIPE_ESHOP_ID', env('APP_NAME')),

    /*
    |--------------------------------------------------------------------------
    | Eshop ids to handle
    |--------------------------------------------------------------------------
    |
    | If set to ['*'] : All webhooks will be handled
    | If set to ['Eshop'] : Just webhooks with eshop_id = 'Eshop' will be handled
    | If set to [] : No webhooks will be handled
    |
    */
    'handle_eshop_ids' => ['*'],
```

By default it does not perform `eshop_id` check, but it is advised to check against your single `eshop_id`.

## Type of Change

-   [ ] Bug fix
-   [x] New feature
-   [ ] Breaking change

## Testing

-   [x] Automated tests added

## Related Issues

Link to related issues if applicable.
