### PR TITLE
Feat: Add cart checked out event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 - Added `currency` relation to `prices`
 - Added `customer_group` relation to `prices`
 - `PaymentOptions` can now be set as hidden (can be used for authorization, but won't be listed via API)
+- The `OrderCreated` event is dispatched from `OrderObserver` right after the order is created
+- Added `CartCheckedOut` event which is dispatched from `CheckoutCart` action
+
+### ⚠️ Breaking changes
+
+- `CartCheckedOut` event is dispatched after checkout instead of `OrderCreated` event
 
 ## 1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Added `customer_group` relation to `prices`
 - `PaymentOptions` can now be set as hidden (can be used for authorization, but won't be listed via API)
 - The `OrderCreated` event is dispatched from `OrderObserver` right after the order is created
+- Processing Stripe webhooks is now controlled by custom `WebhookProfile` which checks `eshop_id`
+  (if configured) in payment intent metadata and either dispatches webhook handlers or discards the webhook calls
 - Added `CartCheckedOut` event which is dispatched from `CheckoutCart` action
 
 ### ⚠️ Breaking changes

--- a/packages/api/src/Domain/Carts/Actions/CheckoutCart.php
+++ b/packages/api/src/Domain/Carts/Actions/CheckoutCart.php
@@ -3,8 +3,10 @@
 namespace Dystore\Api\Domain\Carts\Actions;
 
 use Dystore\Api\Domain\Carts\Contracts\CheckoutCart as CheckoutCartContract;
+use Dystore\Api\Domain\Carts\Events\CartCheckedOut;
 use Dystore\Api\Domain\Carts\Models\Cart;
 use Dystore\Api\Domain\Payments\Actions\CreatePaymentIntent;
+use Dystore\Api\Support\Actions\Action;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Config;
 use Lunar\Base\CartSessionInterface;
@@ -12,7 +14,7 @@ use Lunar\Models\Contracts\Cart as CartContract;
 use Lunar\Models\Contracts\Order as OrderContract;
 use Lunar\Models\Order;
 
-class CheckoutCart implements CheckoutCartContract
+class CheckoutCart extends Action implements CheckoutCartContract
 {
     /**
      * @var CartSessionManager
@@ -28,10 +30,7 @@ class CheckoutCart implements CheckoutCartContract
         $this->createPaymentIntent = App::make(CreatePaymentIntent::class);
     }
 
-    /**
-     * Checkout cart.
-     */
-    public function __invoke(CartContract $cart): OrderContract
+    public function handle(CartContract $cart): OrderContract
     {
         /** @var Cart $cart */
         /** @var Order $order */
@@ -57,6 +56,8 @@ class CheckoutCart implements CheckoutCartContract
         if (Config::get('dystore.general.checkout.forget_cart_after_order_creation', true)) {
             $this->cartSession->forget(delete: false);
         }
+
+        CartCheckedOut::dispatch($cart, $model);
 
         return $model;
     }

--- a/packages/api/src/Domain/Carts/Contracts/CheckoutCart.php
+++ b/packages/api/src/Domain/Carts/Contracts/CheckoutCart.php
@@ -2,4 +2,7 @@
 
 namespace Dystore\Api\Domain\Carts\Contracts;
 
+/**
+ * @see \Dystore\Api\Domain\Carts\Actions\CheckoutCart
+ */
 interface CheckoutCart {}

--- a/packages/api/src/Domain/Carts/Events/CartCheckedOut.php
+++ b/packages/api/src/Domain/Carts/Events/CartCheckedOut.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Dystore\Api\Domain\Carts\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Lunar\Models\Contracts\Cart as CartContract;
+use Lunar\Models\Contracts\Order as OrderContract;
+
+class CartCheckedOut
+{
+    use Dispatchable;
+
+    public function __construct(
+        public CartContract $cart,
+        public OrderContract $order,
+    ) {}
+}

--- a/tests/api/Feature/Domain/Cart/Events/CartCheckedOutTest.php
+++ b/tests/api/Feature/Domain/Cart/Events/CartCheckedOutTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use Dystore\Api\Domain\Carts\Actions\CheckoutCart;
+use Dystore\Api\Domain\Carts\Contracts\CheckoutCart as CheckoutCartContract;
+use Dystore\Api\Domain\Carts\Events\CartCheckedOut;
+use Dystore\Api\Domain\Carts\Factories\CartFactory;
+use Dystore\Api\Domain\Carts\Models\Cart;
+use Dystore\Api\Domain\Users\Models\User;
+use Dystore\Tests\Api\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Event;
+use Lunar\Base\CartSessionInterface;
+use Lunar\Managers\CartSessionManager;
+
+uses(TestCase::class, RefreshDatabase::class)
+    ->group('carts', 'carts.events', 'events');
+
+it('dispatches cart checked out event after checkout', function () {
+    /** @var TestUser $this */
+    Event::fake([
+        CartCheckedOut::class,
+    ]);
+
+    $user = User::factory()->create();
+
+    /** @var CartFactory $cartFactory */
+    $cartFactory = Cart::factory();
+
+    /** @var Cart $cart */
+    $cart = $cartFactory
+        ->withAddresses()
+        ->withLines()
+        ->create();
+
+    /** @var CartSessionManager $cartSession */
+    $cartSession = App::make(CartSessionInterface::class);
+    $cartSession->use($cart);
+
+    /** @var CheckoutCart $checkoutAction */
+    $checkoutAction = App::make(CheckoutCartContract::class);
+
+    $order = $checkoutAction->handle($cart);
+
+    Event::assertDispatched(
+        CartCheckedOut::class,
+        fn (CartCheckedOut $event) => $event->cart->getKey() === $cart->getKey()
+        && $event->order->getKey() === $order->getKey(),
+    );
+});

--- a/tests/api/Feature/Domain/Cart/JsonApi/V1/ReadCartTest.php
+++ b/tests/api/Feature/Domain/Cart/JsonApi/V1/ReadCartTest.php
@@ -9,7 +9,8 @@ use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Event;
 use Lunar\Base\CartSessionInterface;
 
-uses(TestCase::class, RefreshDatabase::class);
+uses(TestCase::class, RefreshDatabase::class)
+    ->group('carts', 'carts.read');
 
 beforeEach(function () {
     /** @var TestCase $this */
@@ -42,7 +43,7 @@ it('can read the cart from session', function () {
         ->assertSuccessful()
         ->assertFetchedOne($cart);
 
-})->group('carts', 'carts.read');
+});
 
 it('can read cart with cart lines included', function () {
     /** @var TestCase $this */
@@ -70,7 +71,7 @@ it('can read cart with cart lines included', function () {
     $response
         ->assertSuccessful();
 
-})->group('carts');
+});
 
 it('can merge carts when user logs in', function () {
     /** @var TestCase $this */
@@ -168,4 +169,4 @@ it('can merge carts when user logs in', function () {
             'purchasable_id' => $line['attributes']['purchasable_id'],
         ]);
     }
-})->group('carts', 'carts.read')->skip('Merging carts is temporarily disabled.');
+})->skip('Merging carts is temporarily disabled.');


### PR DESCRIPTION
## Description

* Added `CartCheckedOut` event which gets dispatched after checkout

## ⚠️ Breaking change

* Previously `OrderCreated` event was dispatched after checkout which is now dispatched right after order is created from `OrderObserver`

## Type of Change

-   [ ] Bug fix
-   [x] New feature
-   [x] Breaking change

## Testing

-   [x] Automated tests added
