### PR TITLE
Fix: Return validation exception (422) instead of lunar exception (500) during checkout

### DIFF
--- a/packages/api/src/Domain/CartLines/Http/Controllers/CartLinesController.php
+++ b/packages/api/src/Domain/CartLines/Http/Controllers/CartLinesController.php
@@ -34,8 +34,6 @@ class CartLinesController extends Controller implements CartLinesControllerContr
         try {
             [, $cartLine] = App::make(AddToCart::class)($data);
         } catch (CartException $e) {
-            $messages = $e->errors();
-
             throw ValidationException::withMessages($e->errors()->getMessages());
         }
 
@@ -54,8 +52,6 @@ class CartLinesController extends Controller implements CartLinesControllerContr
         try {
             [, $cartLine] = App::make(UpdateCartLine::class)($data, $cartLine);
         } catch (CartException $e) {
-            $messages = $e->errors();
-
             throw ValidationException::withMessages($e->errors()->getMessages());
         }
 

--- a/packages/api/src/Domain/Carts/Actions/CheckoutCart.php
+++ b/packages/api/src/Domain/Carts/Actions/CheckoutCart.php
@@ -9,7 +9,9 @@ use Dystore\Api\Domain\Payments\Actions\CreatePaymentIntent;
 use Dystore\Api\Support\Actions\Action;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Config;
+use Illuminate\Validation\ValidationException;
 use Lunar\Base\CartSessionInterface;
+use Lunar\Exceptions\Carts\CartException;
 use Lunar\Models\Contracts\Cart as CartContract;
 use Lunar\Models\Contracts\Order as OrderContract;
 use Lunar\Models\Order;
@@ -34,9 +36,13 @@ class CheckoutCart extends Action implements CheckoutCartContract
     {
         /** @var Cart $cart */
         /** @var Order $order */
-        $order = $cart->createOrder(
-            allowMultipleOrders: Config::get('lunar.cart_session.allow_multiple_orders_per_cart', false),
-        );
+        try {
+            $order = $cart->createOrder(
+                allowMultipleOrders: Config::get('lunar.cart_session.allow_multiple_orders_per_cart', false),
+            );
+        } catch (CartException $e) {
+            throw ValidationException::withMessages($e->errors()->getMessages());
+        }
 
         $model = Order::modelClass()::query()
             ->with([

--- a/packages/api/src/Domain/Carts/Http/Controllers/CheckoutCartController.php
+++ b/packages/api/src/Domain/Carts/Http/Controllers/CheckoutCartController.php
@@ -10,8 +10,10 @@ use Dystore\Api\Domain\Carts\Contracts\CurrentSessionCart;
 use Dystore\Api\Domain\Carts\JsonApi\V1\CheckoutCartRequest;
 use Dystore\Api\Domain\Carts\Models\Cart;
 use Dystore\Api\Domain\Orders\Models\Order;
+use Illuminate\Validation\ValidationException;
 use LaravelJsonApi\Contracts\Store\Store as StoreContract;
 use LaravelJsonApi\Core\Responses\DataResponse;
+use Lunar\Exceptions\Carts\CartException;
 
 class CheckoutCartController extends Controller implements CheckoutCartControllerContract
 {
@@ -32,8 +34,12 @@ class CheckoutCartController extends Controller implements CheckoutCartControlle
             $createUserFromCartAction($cart);
         }
 
-        /** @var Order $order */
-        $order = ($checkoutCartAction)($cart);
+        try {
+            /** @var Order $order */
+            $order = ($checkoutCartAction)($cart);
+        } catch (CartException $e) {
+            throw ValidationException::withMessages($e->errors()->getMessages());
+        }
 
         return DataResponse::make($order)
             ->withIncludePaths([

--- a/packages/api/src/Domain/Carts/Http/Controllers/CheckoutCartController.php
+++ b/packages/api/src/Domain/Carts/Http/Controllers/CheckoutCartController.php
@@ -10,10 +10,8 @@ use Dystore\Api\Domain\Carts\Contracts\CurrentSessionCart;
 use Dystore\Api\Domain\Carts\JsonApi\V1\CheckoutCartRequest;
 use Dystore\Api\Domain\Carts\Models\Cart;
 use Dystore\Api\Domain\Orders\Models\Order;
-use Illuminate\Validation\ValidationException;
 use LaravelJsonApi\Contracts\Store\Store as StoreContract;
 use LaravelJsonApi\Core\Responses\DataResponse;
-use Lunar\Exceptions\Carts\CartException;
 
 class CheckoutCartController extends Controller implements CheckoutCartControllerContract
 {
@@ -34,12 +32,8 @@ class CheckoutCartController extends Controller implements CheckoutCartControlle
             $createUserFromCartAction($cart);
         }
 
-        try {
-            /** @var Order $order */
-            $order = ($checkoutCartAction)($cart);
-        } catch (CartException $e) {
-            throw ValidationException::withMessages($e->errors()->getMessages());
-        }
+        /** @var Order $order */
+        $order = ($checkoutCartAction)($cart);
 
         return DataResponse::make($order)
             ->withIncludePaths([


### PR DESCRIPTION
* Return 422 with messages instead of 500 during checkout when `CartException` is thrown