### PR TITLE
Feat: Make Laravel 12 compatible

### DIFF
--- a/.github/workflows/static-analysis.yaml
+++ b/.github/workflows/static-analysis.yaml
@@ -12,8 +12,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.2, 8.3]
-        laravel: [11]
+        php: [8.3, 8.4]
+        laravel: [11, 12]
 
     name: "PHP ${{ matrix.php }} - L${{ matrix.laravel }}"
     runs-on: "ubuntu-latest"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.2, 8.3]
-        laravel: [11.*]
+        php: [8.3, 8.4]
+        laravel: [11, 12]
         testsuite:
           - api
           - newsletter

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,6 @@
   "homepage": "https://github.com/dystcz/dystore-api",
   "require": {
     "php": "^8.2",
-    "ext-redis": "*",
     "h4kuna/ares": "^3.0",
     "illuminate/support": "^11.0|^12.0",
     "laravel-json-api/laravel": "^5.0",

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     "php": "^8.2",
     "ext-redis": "*",
     "h4kuna/ares": "^3.0",
-    "illuminate/support": "^11.0",
+    "illuminate/support": "^11.0|^12.0",
     "laravel-json-api/laravel": "^5.0",
     "laravel-json-api/non-eloquent": "^4.0",
     "laravel-notification-channels/discord": "^1.5",

--- a/packages/api/composer.json
+++ b/packages/api/composer.json
@@ -20,10 +20,10 @@
   ],
   "require": {
     "php": "^8.2",
-    "illuminate/support": "^11.0",
+    "illuminate/support": "^11.0|^12.0",
     "laravel-json-api/laravel": "^5.0",
     "laravel-json-api/non-eloquent": "^4.0",
-    "lunarphp/lunar": "^1.0.0-beta.9",
+    "lunarphp/lunar": "1.0.0-beta.10",
     "staudenmeir/eloquent-has-many-deep": "^1.20"
   },
   "autoload": {

--- a/packages/newsletter/composer.json
+++ b/packages/newsletter/composer.json
@@ -1,60 +1,60 @@
 {
-    "name": "dystcz/dystore-newsletter",
-    "description": "Add the possibility to sign up to newsletter lists to your Dystore backend",
-    "keywords": [
-        "dystopia",
-        "dystore",
-        "lunar",
-        "newsletter"
-    ],
-    "homepage": "https://github.com/dystcz/dystore",
-    "license": "MIT",
-    "type": "library",
-    "authors": [
-        {
-            "name": "Dystopia",
-            "homepage": "https://dy.st/"
-        }
-    ],
-    "require": {
-        "php": "^8.2",
-        "dystcz/dystore-api": "^1.1",
-        "illuminate/support": "^11.0",
-        "spatie/laravel-newsletter": "^5.1"
+  "name": "dystcz/dystore-newsletter",
+  "description": "Add the possibility to sign up to newsletter lists to your Dystore backend",
+  "keywords": [
+    "dystopia",
+    "dystore",
+    "lunar",
+    "newsletter"
+  ],
+  "homepage": "https://github.com/dystcz/dystore",
+  "license": "MIT",
+  "type": "library",
+  "authors": [
+    {
+      "name": "Dystopia",
+      "homepage": "https://dy.st/"
+    }
+  ],
+  "require": {
+    "php": "^8.2",
+    "dystcz/dystore-api": "^1.1",
+    "illuminate/support": "^11.0|^12.0",
+    "spatie/laravel-newsletter": "^5.1"
+  },
+  "suggest": {
+    "spatie/mailcoach-sdk-php": "For working with Mailcoach",
+    "drewm/mailchimp-api": "For working with MailChimp",
+    "getbrevo/brevo-php": "For working with Brevo"
+  },
+  "require-dev": {
+    "drewm/mailchimp-api": "^2.5",
+    "getbrevo/brevo-php": "^1.0",
+    "spatie/mailcoach-sdk-php": "^1.1"
+  },
+  "autoload": {
+    "psr-4": {
+      "Dystore\\Newsletter\\": "src",
+      "Dystore\\Newsletter\\Database\\Factories\\": "database/factories",
+      "Dystore\\Newsletter\\Database\\State\\": "database/state"
     },
-    "suggest": {
-        "spatie/mailcoach-sdk-php": "For working with Mailcoach",
-        "drewm/mailchimp-api": "For working with MailChimp",
-        "getbrevo/brevo-php": "For working with Brevo"
-    },
-    "require-dev": {
-        "drewm/mailchimp-api": "^2.5",
-        "getbrevo/brevo-php": "^1.0",
-        "spatie/mailcoach-sdk-php": "^1.1"
-    },
-    "autoload": {
-        "psr-4": {
-            "Dystore\\Newsletter\\": "src",
-            "Dystore\\Newsletter\\Database\\Factories\\": "database/factories",
-            "Dystore\\Newsletter\\Database\\State\\": "database/state"
-        },
-        "files": [
-            "autoload.php"
-        ]
-    },
-    "config": {
-        "sort-packages": true,
-        "allow-plugins": {
-            "pestphp/pest-plugin": true
-        }
-    },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "Dystore\\Newsletter\\NewsletterServiceProvider"
-            ]
-        }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    "files": [
+      "autoload.php"
+    ]
+  },
+  "config": {
+    "sort-packages": true,
+    "allow-plugins": {
+      "pestphp/pest-plugin": true
+    }
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Dystore\\Newsletter\\NewsletterServiceProvider"
+      ]
+    }
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true
 }

--- a/packages/product-notifications/composer.json
+++ b/packages/product-notifications/composer.json
@@ -1,50 +1,50 @@
 {
-    "name": "dystcz/dystore-product-notifications",
-    "description": "Dystore product notifications",
-    "keywords": [
-        "dystopia",
-        "lunar",
-        "dystore",
-        "laravel",
-        "php"
-    ],
-    "homepage": "https://github.com/dystcz/dystore",
-    "license": "MIT",
-    "type": "library",
-    "authors": [
-        {
-            "name": "Dystopia",
-            "homepage": "https://dy.st/"
-        }
-    ],
-    "require": {
-        "php": "^8.2",
-        "dystcz/dystore-api": "^1.1",
-        "illuminate/support": "^11.0"
+  "name": "dystcz/dystore-product-notifications",
+  "description": "Dystore product notifications",
+  "keywords": [
+    "dystopia",
+    "lunar",
+    "dystore",
+    "laravel",
+    "php"
+  ],
+  "homepage": "https://github.com/dystcz/dystore",
+  "license": "MIT",
+  "type": "library",
+  "authors": [
+    {
+      "name": "Dystopia",
+      "homepage": "https://dy.st/"
+    }
+  ],
+  "require": {
+    "php": "^8.2",
+    "illuminate/support": "^11.0|^12.0",
+    "dystcz/dystore-api": "^1.1"
+  },
+  "autoload": {
+    "psr-4": {
+      "Dystore\\ProductNotifications\\": "src",
+      "Dystore\\ProductNotifications\\Database\\Factories\\": "database/factories",
+      "Dystore\\ProductNotifications\\Database\\State\\": "database/state"
     },
-    "autoload": {
-        "psr-4": {
-            "Dystore\\ProductNotifications\\": "src",
-            "Dystore\\ProductNotifications\\Database\\Factories\\": "database/factories",
-            "Dystore\\ProductNotifications\\Database\\State\\": "database/state"
-        },
-        "files": [
-            "autoload.php"
-        ]
-    },
-    "config": {
-        "sort-packages": true,
-        "allow-plugins": {
-            "pestphp/pest-plugin": true
-        }
-    },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "Dystore\\ProductNotifications\\ProductNotificationsServiceProvider"
-            ]
-        }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    "files": [
+      "autoload.php"
+    ]
+  },
+  "config": {
+    "sort-packages": true,
+    "allow-plugins": {
+      "pestphp/pest-plugin": true
+    }
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Dystore\\ProductNotifications\\ProductNotificationsServiceProvider"
+      ]
+    }
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true
 }

--- a/packages/product-views/composer.json
+++ b/packages/product-views/composer.json
@@ -1,51 +1,53 @@
 {
-    "name": "dystcz/dystore-product-views",
-    "description": "Track product views in yout Dystore backend",
-    "keywords": [
-        "dystopia",
-        "lunar",
-        "dystore",
-        "laravel",
-        "php"
-    ],
-    "homepage": "https://github.com/dystcz/dystore",
-    "license": "MIT",
-    "type": "library",
-    "authors": [
-        {
-            "name": "Dystopia",
-            "homepage": "https://dy.st/"
-        }
-    ],
-    "require": {
-        "php": "^8.2",
-        "dystcz/dystore-api": "^1.1",
-        "illuminate/support": "^11.0",
-        "ext-redis": "*"
+  "name": "dystcz/dystore-product-views",
+  "description": "Track product views in yout Dystore backend",
+  "keywords": [
+    "dystopia",
+    "lunar",
+    "dystore",
+    "laravel",
+    "php"
+  ],
+  "homepage": "https://github.com/dystcz/dystore",
+  "license": "MIT",
+  "type": "library",
+  "authors": [
+    {
+      "name": "Dystopia",
+      "homepage": "https://dy.st/"
+    }
+  ],
+  "require": {
+    "php": "^8.2",
+    "illuminate/support": "^11.0|^12.0",
+    "dystcz/dystore-api": "^1.1"
+  },
+  "suggest": {
+    "ext-redis": "For using product views"
+  },
+  "autoload": {
+    "psr-4": {
+      "Dystore\\ProductViews\\": "src",
+      "Dystore\\ProductViews\\Database\\Factories\\": "database/factories",
+      "Dystore\\ProductViews\\Database\\State\\": "database/state"
     },
-    "autoload": {
-        "psr-4": {
-            "Dystore\\ProductViews\\": "src",
-            "Dystore\\ProductViews\\Database\\Factories\\": "database/factories",
-            "Dystore\\ProductViews\\Database\\State\\": "database/state"
-        },
-        "files": [
-            "autoload.php"
-        ]
-    },
-    "config": {
-        "sort-packages": true,
-        "allow-plugins": {
-            "pestphp/pest-plugin": true
-        }
-    },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "Dystore\\ProductViews\\ProductViewsServiceProvider"
-            ]
-        }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    "files": [
+      "autoload.php"
+    ]
+  },
+  "config": {
+    "sort-packages": true,
+    "allow-plugins": {
+      "pestphp/pest-plugin": true
+    }
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Dystore\\ProductViews\\ProductViewsServiceProvider"
+      ]
+    }
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true
 }

--- a/packages/reviews/composer.json
+++ b/packages/reviews/composer.json
@@ -1,50 +1,50 @@
 {
-    "name": "dystcz/dystore-reviews",
-    "description": "Dystore Product Reviews",
-    "keywords": [
-        "dystopia",
-        "lunar",
-        "dystore",
-        "laravel",
-        "php"
-    ],
-    "homepage": "https://github.com/dystcz/dystore",
-    "license": "MIT",
-    "type": "library",
-    "authors": [
-        {
-            "name": "Dystopia",
-            "homepage": "https://dy.st/"
-        }
-    ],
-    "require": {
-        "php": "^8.2",
-        "dystcz/dystore-api": "^1.1",
-        "illuminate/support": "^11.0"
+  "name": "dystcz/dystore-reviews",
+  "description": "Dystore Product Reviews",
+  "keywords": [
+    "dystopia",
+    "lunar",
+    "dystore",
+    "laravel",
+    "php"
+  ],
+  "homepage": "https://github.com/dystcz/dystore",
+  "license": "MIT",
+  "type": "library",
+  "authors": [
+    {
+      "name": "Dystopia",
+      "homepage": "https://dy.st/"
+    }
+  ],
+  "require": {
+    "php": "^8.2",
+    "dystcz/dystore-api": "^1.1",
+    "illuminate/support": "^11.0|^12.0"
+  },
+  "autoload": {
+    "psr-4": {
+      "Dystore\\Reviews\\": "src",
+      "Dystore\\Reviews\\Database\\Factories\\": "database/factories",
+      "Dystore\\Reviews\\Database\\State\\": "database/state"
     },
-    "autoload": {
-        "psr-4": {
-            "Dystore\\Reviews\\": "src",
-            "Dystore\\Reviews\\Database\\Factories\\": "database/factories",
-            "Dystore\\Reviews\\Database\\State\\": "database/state"
-        },
-        "files": [
-            "autoload.php"
-        ]
-    },
-    "config": {
-        "sort-packages": true,
-        "allow-plugins": {
-            "pestphp/pest-plugin": true
-        }
-    },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "Dystore\\Reviews\\ReviewsServiceProvider"
-            ]
-        }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    "files": [
+      "autoload.php"
+    ]
+  },
+  "config": {
+    "sort-packages": true,
+    "allow-plugins": {
+      "pestphp/pest-plugin": true
+    }
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Dystore\\Reviews\\ReviewsServiceProvider"
+      ]
+    }
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true
 }

--- a/packages/stripe/composer.json
+++ b/packages/stripe/composer.json
@@ -1,54 +1,53 @@
 {
-    "name": "dystcz/dystore-stripe",
-    "description": "Dystore Stripe payment adapter",
-    "homepage": "https://github.com/dystcz/dystore",
-    "license": "MIT",
-    "type": "library",
-    "keywords": [
-        "dystopia",
-        "lunar",
-        "dystore",
-        "laravel",
-        "php",
-        "stripe"
-    ],
-    "authors": [
-        {
-            "name": "Dystopia",
-            "homepage": "https://dy.st/"
-        }
-    ],
-    "require": {
-        "php": "^8.2",
-        "illuminate/support": "^11.0",
-        "dystcz/dystore-api": "^1.1",
-        "lunarphp/stripe": "^1.0.0",
-        "spatie/laravel-stripe-webhooks": "^3.6"
+  "name": "dystcz/dystore-stripe",
+  "description": "Dystore Stripe payment adapter",
+  "homepage": "https://github.com/dystcz/dystore",
+  "license": "MIT",
+  "type": "library",
+  "keywords": [
+    "dystopia",
+    "lunar",
+    "dystore",
+    "laravel",
+    "php",
+    "stripe"
+  ],
+  "authors": [
+    {
+      "name": "Dystopia",
+      "homepage": "https://dy.st/"
+    }
+  ],
+  "require": {
+    "php": "^8.2",
+    "dystcz/dystore-api": "^1.1",
+    "lunarphp/stripe": "^1.0.0",
+    "spatie/laravel-stripe-webhooks": "^3.6"
+  },
+  "autoload": {
+    "psr-4": {
+      "Dystore\\Stripe\\": "src",
+      "Dystore\\Stripe\\Database\\Factories\\": "database/factories",
+      "Dystore\\Stripe\\Database\\State\\": "database/state"
     },
-    "autoload": {
-        "psr-4": {
-            "Dystore\\Stripe\\": "src",
-            "Dystore\\Stripe\\Database\\Factories\\": "database/factories",
-            "Dystore\\Stripe\\Database\\State\\": "database/state"
-        },
-        "files": [
-            "autoload.php"
-        ]
-    },
-    "config": {
-        "sort-packages": true,
-        "allow-plugins": {
-            "pestphp/pest-plugin": true,
-            "phpstan/extension-installer": true
-        }
-    },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "Dystore\\Stripe\\StripeServiceProvider"
-            ]
-        }
-    },
-    "minimum-stability": "dev",
-    "prefer-stable": true
+    "files": [
+      "autoload.php"
+    ]
+  },
+  "config": {
+    "sort-packages": true,
+    "allow-plugins": {
+      "pestphp/pest-plugin": true,
+      "phpstan/extension-installer": true
+    }
+  },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Dystore\\Stripe\\StripeServiceProvider"
+      ]
+    }
+  },
+  "minimum-stability": "dev",
+  "prefer-stable": true
 }


### PR DESCRIPTION
* Update `illuminate/support` version to `^11.0|^12.0` across packages
* Update Github test workflow to run on php `8.3` & `8.4` and Laravel `11` & `12`
* Update Github static analysis workflow to run on php `8.3` & `8.4` and Laravel `11` & `12`