### PR TITLE
Fix: Payment prices activity log errors workaround

### DIFF
--- a/packages/api/src/Domain/Orders/Concerns/InteractsWithDystoreApi.php
+++ b/packages/api/src/Domain/Orders/Concerns/InteractsWithDystoreApi.php
@@ -72,4 +72,21 @@ trait InteractsWithDystoreApi
             ->hasOne(Transaction::modelClass())
             ->latestOfMany();
     }
+
+    /**
+     * Attribute activity log blacklist.
+     *
+     * @return string[]
+     */
+    public static function getDefaultLogExcept(): array
+    {
+        return [
+            ...parent::getDefaultLogExcept(),
+
+            // WARNING: Because of: https://github.com/lunarphp/lunar/commit/e25b7bcef152a94e45251803e80f682d92424f28
+            // NOTICE  Object of class Lunar\DataTypes\Price could not be converted to int in vendor/spatie/laravel-activitylog/src/Traits/LogsActivity.php on line 313.
+            'payment_total',
+            'payment_breakdown',
+        ];
+    }
 }

--- a/tests/api/Feature/Domain/ProductVariants/JsonApi/V1/ProductVariantHighestPriceRelationshipTest.php
+++ b/tests/api/Feature/Domain/ProductVariants/JsonApi/V1/ProductVariantHighestPriceRelationshipTest.php
@@ -4,8 +4,13 @@ use Dystore\Api\Domain\Products\Models\Product;
 use Dystore\Api\Domain\ProductVariants\Factories\ProductVariantFactory;
 use Dystore\Tests\Api\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\App;
+use Lunar\Base\StorefrontSessionInterface;
+use Lunar\Models\CustomerGroup;
 
-uses(TestCase::class, RefreshDatabase::class);
+uses(TestCase::class, RefreshDatabase::class)
+    ->group('product_variants');
 
 it('can read highest price through relationship', function () {
     /** @var TestCase $this */
@@ -25,4 +30,55 @@ it('can read highest price through relationship', function () {
         ->assertSuccessful()
         ->assertFetchedOne($variant->prices->sortByDesc('price')->first())
         ->assertDoesntHaveIncluded();
-})->group('product_variants');
+});
+
+it('can read correct highest price when customer group is set', function () {
+    /** @var TestCase $this */
+    $variant = ProductVariantFactory::new()
+        ->for(Product::factory(), 'product')
+        ->withPrice()
+        ->withPrice()
+        ->withPrice()
+        ->create();
+
+    $highestPrice = $variant->prices->sortByDesc(fn ($price) => $price->price->value)->first();
+
+    $customerGroup = CustomerGroup::factory()
+        ->create();
+
+    $highestPrice->update([
+        'customer_group_id' => $customerGroup->getKey(),
+    ]);
+
+    $highestBasePrice = $variant->prices
+        ->filter(fn ($price) => $price->getKey() !== $highestPrice->getKey())
+        ->sortByDesc(fn ($price) => $price->price->value)
+        ->first();
+
+    $response = $this
+        ->jsonApi()
+        ->expects('prices')
+        ->get(serverUrl("/product_variants/{$variant->getRouteKey()}/highest_price"));
+
+    $response
+        ->assertSuccessful()
+        ->assertFetchedOne($highestBasePrice)
+        ->assertDoesntHaveIncluded();
+
+    App::make(StorefrontSessionInterface::class)
+        ->setCustomerGroups(Collection::make([$customerGroup]));
+
+    $response = $this
+        ->jsonApi()
+        ->expects('prices')
+        ->get(serverUrl("/product_variants/{$variant->getRouteKey()}/highest_price"));
+
+    $response
+        ->assertSuccessful()
+        ->assertFetchedOne($highestPrice)
+        ->assertDoesntHaveIncluded();
+});
+
+afterEach(function () {
+    App::make(StorefrontSessionInterface::class)->forget();
+});

--- a/tests/api/Feature/Domain/ProductVariants/JsonApi/V1/ProductVariantLowestPriceRelationshipTest.php
+++ b/tests/api/Feature/Domain/ProductVariants/JsonApi/V1/ProductVariantLowestPriceRelationshipTest.php
@@ -4,8 +4,13 @@ use Dystore\Api\Domain\Products\Models\Product;
 use Dystore\Api\Domain\ProductVariants\Factories\ProductVariantFactory;
 use Dystore\Tests\Api\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\App;
+use Lunar\Base\StorefrontSessionInterface;
+use Lunar\Models\CustomerGroup;
 
-uses(TestCase::class, RefreshDatabase::class);
+uses(TestCase::class, RefreshDatabase::class)
+    ->group('product_variants');
 
 it('can read lowest price through relationship', function () {
     /** @var TestCase $this */
@@ -25,4 +30,51 @@ it('can read lowest price through relationship', function () {
         ->assertSuccessful()
         ->assertFetchedOne($variant->prices->sortBy('price')->first())
         ->assertDoesntHaveIncluded();
-})->group('product_variants');
+});
+
+it('can read correct lowest price when customer group is set', function () {
+    /** @var TestCase $this */
+    $variant = ProductVariantFactory::new()
+        ->for(Product::factory(), 'product')
+        ->withPrice()
+        ->withPrice()
+        ->withPrice()
+        ->create();
+
+    $lowestPrice = $variant->prices->sortBy(fn ($price) => $price->price->value)->first();
+
+    $customerGroup = CustomerGroup::factory()
+        ->create();
+
+    $lowestPrice->update([
+        'customer_group_id' => $customerGroup->getKey(),
+    ]);
+
+    $lowestBasePrice = $variant->prices
+        ->filter(fn ($price) => $price->getKey() !== $lowestPrice->getKey())
+        ->sortBy(fn ($price) => $price->price->value)
+        ->first();
+
+    $response = $this
+        ->jsonApi()
+        ->expects('prices')
+        ->get(serverUrl("/product_variants/{$variant->getRouteKey()}/lowest_price"));
+
+    $response
+        ->assertSuccessful()
+        ->assertFetchedOne($lowestBasePrice)
+        ->assertDoesntHaveIncluded();
+
+    App::make(StorefrontSessionInterface::class)
+        ->setCustomerGroups(Collection::make([$customerGroup]));
+
+    $response = $this
+        ->jsonApi()
+        ->expects('prices')
+        ->get(serverUrl("/product_variants/{$variant->getRouteKey()}/lowest_price"));
+
+    $response
+        ->assertSuccessful()
+        ->assertFetchedOne($lowestPrice)
+        ->assertDoesntHaveIncluded();
+});

--- a/tests/api/Feature/Domain/Products/JsonApi/V1/ProductCheapestVariantRelationshipTest.php
+++ b/tests/api/Feature/Domain/Products/JsonApi/V1/ProductCheapestVariantRelationshipTest.php
@@ -5,6 +5,7 @@ use Dystore\Api\Domain\ProductVariants\Factories\ProductVariantFactory;
 use Dystore\Tests\Api\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\App;
 use Lunar\Base\StorefrontSessionInterface;
 use Lunar\Models\Currency;
 use Lunar\Models\CustomerGroup;
@@ -45,9 +46,7 @@ it('can read correct cheapest variant through relationship when customer group i
     /** @var Currency $currency */
     $currency = Currency::getDefault();
 
-    $cheapestVariant = $product->variants->sortBy(
-        fn ($variant) => $variant->prices->sortBy('price')->first()->price,
-    )->first();
+    $cheapestVariant = $product->variants->sortBy(fn ($variant) => $variant->prices->min('price'))->first();
 
     $lowestPrice = $cheapestVariant->prices->first()->price;
 

--- a/tests/api/Feature/Domain/Products/JsonApi/V1/ProductHighestPriceRelationshipTest.php
+++ b/tests/api/Feature/Domain/Products/JsonApi/V1/ProductHighestPriceRelationshipTest.php
@@ -29,6 +29,50 @@ it('can read highest price through relationship', function () {
         ->assertDoesntHaveIncluded();
 });
 
+it('can read correct highest price when customer group is set', function () {
+    /** @var TestCase $this */
+    $product = ProductFactory::new()
+        ->withPrices(3)
+        ->create();
+
+    $highestPrice = $product->prices->sortByDesc(fn ($price) => $price->price->value)->first();
+
+    $customerGroup = CustomerGroup::factory()
+        ->create();
+
+    $highestPrice->update([
+        'customer_group_id' => $customerGroup->getKey(),
+    ]);
+
+    $highestBasePrice = $product->prices
+        ->filter(fn ($price) => $price->getKey() !== $highestPrice->getKey())
+        ->sortByDesc(fn ($price) => $price->price->value)
+        ->first();
+
+    $response = $this
+        ->jsonApi()
+        ->expects('prices')
+        ->get(serverUrl("/products/{$product->getRouteKey()}/highest_price"));
+
+    $response
+        ->assertSuccessful()
+        ->assertFetchedOne($highestBasePrice)
+        ->assertDoesntHaveIncluded();
+
+    App::make(StorefrontSessionInterface::class)
+        ->setCustomerGroups(Collection::make([$customerGroup]));
+
+    $response = $this
+        ->jsonApi()
+        ->expects('prices')
+        ->get(serverUrl("/products/{$product->getRouteKey()}/highest_price"));
+
+    $response
+        ->assertSuccessful()
+        ->assertFetchedOne($highestPrice)
+        ->assertDoesntHaveIncluded();
+});
+
 it('can read highest price through relationship with includes', function (string $includePath, string $type, callable $getModel) {
     /** @var TestCase $this */
     $product = ProductFactory::new()

--- a/tests/api/Feature/Domain/Products/JsonApi/V1/ProductHighestPriceRelationshipTest.php
+++ b/tests/api/Feature/Domain/Products/JsonApi/V1/ProductHighestPriceRelationshipTest.php
@@ -4,6 +4,7 @@ use Dystore\Api\Domain\Products\Factories\ProductFactory;
 use Dystore\Tests\Api\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\App;
 use Lunar\Base\StorefrontSessionInterface;
 use Lunar\Models\Contracts\Price as PriceContract;
 use Lunar\Models\CustomerGroup;

--- a/tests/api/Feature/Domain/Products/JsonApi/V1/ProductLowestPriceRelationshipTest.php
+++ b/tests/api/Feature/Domain/Products/JsonApi/V1/ProductLowestPriceRelationshipTest.php
@@ -59,18 +59,18 @@ it('can read correct lowest price when customer group is set', function () {
         ->assertFetchedOne($lowestBasePrice)
         ->assertDoesntHaveIncluded();
 
-    // App::make(StorefrontSessionInterface::class)
-    //     ->setCustomerGroups(Collection::make([$customerGroup]));
-    //
-    // $response = $this
-    //     ->jsonApi()
-    //     ->expects('prices')
-    //     ->get(serverUrl("/products/{$product->getRouteKey()}/lowest_price"));
-    //
-    // $response
-    //     ->assertSuccessful()
-    //     ->assertFetchedOne($lowestPrice)
-    //     ->assertDoesntHaveIncluded();
+    App::make(StorefrontSessionInterface::class)
+        ->setCustomerGroups(Collection::make([$customerGroup]));
+
+    $response = $this
+        ->jsonApi()
+        ->expects('prices')
+        ->get(serverUrl("/products/{$product->getRouteKey()}/lowest_price"));
+
+    $response
+        ->assertSuccessful()
+        ->assertFetchedOne($lowestPrice)
+        ->assertDoesntHaveIncluded();
 });
 
 it('can read lowest price through relationship with includes', function (string $includePath, string $type, callable $getModel) {


### PR DESCRIPTION
## Description

* Fixes https://github.com/dystcz/dystore-api/issues/214
* Added `payment_total` and `payment_breakdown` to activity log blacklist
* Added tests