### PR TITLE
Feat: Reenable hashids

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -108,6 +108,7 @@
     "laravel-json-api/laravel": "^5.1",
     "laravel-json-api/non-eloquent": "^4.2",
     "laravel-notification-channels/discord": "^1.5",
+    "laravel-json-api/hashids": "^3.2",
     "lunarphp/lunar": "1.0.0-beta.20",
     "lunarphp/stripe": "^1.0.0",
     "spatie/laravel-newsletter": "^5.1",

--- a/packages/api/composer.json
+++ b/packages/api/composer.json
@@ -23,6 +23,7 @@
     "illuminate/support": "^11.0|^12.0",
     "laravel-json-api/laravel": "^5.1",
     "laravel-json-api/non-eloquent": "^4.2",
+    "laravel-json-api/hashids": "^3.2",
     "lunarphp/lunar": "1.0.0-beta.20",
     "staudenmeir/eloquent-has-many-deep": "^1.20"
   },

--- a/packages/api/src/ApiHashidsServiceProvider.php
+++ b/packages/api/src/ApiHashidsServiceProvider.php
@@ -14,9 +14,9 @@ class ApiHashidsServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        // if (Api::usesHashids()) {
-        //     HashidsConnections::registerConnections();
-        // }
+        if (Api::usesHashids()) {
+            HashidsConnections::registerConnections();
+        }
     }
 
     /**
@@ -24,13 +24,13 @@ class ApiHashidsServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        // // Automatically apply the package configuration.
-        // $this->mergeConfigFrom(__DIR__.'/../config/hashids.php', 'hashids');
-        //
-        // // Register payment adapters register.
-        // $this->app->singleton(
-        //     \Dystore\Api\Hashids\Contracts\HashidsConnectionsManager::class,
-        //     fn () => new \Dystore\Api\Hashids\Managers\HashidsConnectionsManager,
-        // );
+        // Automatically apply the package configuration.
+        $this->mergeConfigFrom(__DIR__.'/../config/hashids.php', 'hashids');
+
+        // Register payment adapters register.
+        $this->app->singleton(
+            \Dystore\Api\Hashids\Contracts\HashidsConnectionsManager::class,
+            fn () => new \Dystore\Api\Hashids\Managers\HashidsConnectionsManager,
+        );
     }
 }

--- a/packages/api/src/Domain/JsonApi/Eloquent/Schema.php
+++ b/packages/api/src/Domain/JsonApi/Eloquent/Schema.php
@@ -272,13 +272,11 @@ abstract class Schema extends BaseSchema implements ExtendableContract, SchemaCo
      */
     protected function idField(?string $column = null): ID // ID|HashId
     {
-        // WARNING: Hashids (laravel-json-api/laravel) currently incompatible with laravel-json-api/laravel
-        //
-        // if (Api::usesHashids()) {
-        //     return HashId::make($column)
-        //         ->useConnection(ModelKey::get(self::model()))
-        //         ->alreadyHashed();
-        // }
+        if (Api::usesHashids()) {
+            return HashId::make($column)
+                ->useConnection(ModelKey::get(self::model()))
+                ->alreadyHashed();
+        }
 
         return ID::make($column);
     }

--- a/packages/api/src/Domain/ProductVariants/JsonApi/V1/ProductVariantSchema.php
+++ b/packages/api/src/Domain/ProductVariants/JsonApi/V1/ProductVariantSchema.php
@@ -174,7 +174,7 @@ class ProductVariantSchema extends Schema
         return [
             WhereIdIn::make($this),
 
-            WhereIdNotIn::make($this),
+            WhereIdNotIn::make($this, 'except'),
 
             WhereHas::make($this, 'urls', 'url')
                 ->singular(),

--- a/packages/api/src/Domain/Products/JsonApi/V1/ProductSchema.php
+++ b/packages/api/src/Domain/Products/JsonApi/V1/ProductSchema.php
@@ -262,7 +262,7 @@ class ProductSchema extends Schema
         return [
             WhereIdIn::make($this),
 
-            WhereIdNotIn::make($this),
+            WhereIdNotIn::make($this, 'except'),
 
             InStockFilter::make('in_stock'),
 

--- a/packages/api/src/Hashids/Traits/HashesRouteKey.php
+++ b/packages/api/src/Hashids/Traits/HashesRouteKey.php
@@ -10,84 +10,82 @@ use Vinkla\Hashids\Facades\Hashids as HashidsFacade;
 
 trait HashesRouteKey
 {
-    // WARNING: Hashids (laravel-json-api/laravel) currently incompatible with laravel-json-api/laravel
-    //
-    // /**
-    //  * Get the value of the model's route key.
-    //  */
-    // public function getRouteKey(): mixed
-    // {
-    //     if (! Api::usesHashids()) {
-    //         return parent::getRouteKey();
-    //     }
-    //
-    //     /** @var \Lunar\Base\BaseModel $model */
-    //     $model = $this;
-    //
-    //     return $this->hashIds()->encode($model->getAttribute($model->getRouteKeyName()));
-    // }
-    //
-    // /**
-    //  * Retrieve the model for a bound value.
-    //  *
-    //  * @param  mixed  $value
-    //  * @param  string|null  $field
-    //  * @return \Illuminate\Database\Eloquent\Model|null
-    //  */
-    // public function resolveRouteBinding($value, $field = null)
-    // {
-    //     if (! Api::usesHashids()) {
-    //         return parent::resolveRouteBinding($value, $field);
-    //     }
-    //
-    //     /** @var \Lunar\Base\BaseModel $model */
-    //     $model = $this;
-    //
-    //     if (empty($field) || $field === $model->getRouteKeyName()) {
-    //         return $model->newQuery()->where(
-    //             $field ?: $model->getRouteKeyName(),
-    //             $this->decodedRouteKey($value)
-    //         )->firstOrFail();
-    //     }
-    //
-    //     return $model
-    //         ->newQuery()
-    //         ->where($field, $value)
-    //         ->firstOrFail();
-    // }
-    //
-    // /**
-    //  * Encode routeKey.
-    //  */
-    // public function encodedRouteKey(mixed $value): string
-    // {
-    //     return $this->hashIds()->encode($value);
-    // }
-    //
-    // /**
-    //  * Decode hashed routeKey.
-    //  */
-    // public function decodedRouteKey(mixed $value): mixed
-    // {
-    //     return Arr::first($this->hashIds()->decode($value));
-    // }
-    //
-    // /**
-    //  * Get connection name for Hashids.
-    //  */
-    // protected function hashIds(): Hashids
-    // {
-    //     return HashidsFacade::connection($this->getHashidsConnection());
-    // }
-    //
-    // /**
-    //  * Get connection name for Hashids.
-    //  */
-    // protected function getHashidsConnection(): string
-    // {
-    //     /** @var \Lunar\Base\BaseModel $model */
-    //     $model = $this;
-    //
-    //     return HashidsConnections::getModelConnection($model->getMorphClass());
-    // }
+    /**
+     * Get the value of the model's route key.
+     */
+    public function getRouteKey(): mixed
+    {
+        if (! Api::usesHashids()) {
+            return parent::getRouteKey();
+        }
+
+        /** @var \Lunar\Base\BaseModel $model */
+        $model = $this;
+
+        return $this->hashIds()->encode($model->getAttribute($model->getRouteKeyName()));
+    }
+
+    /**
+     * Retrieve the model for a bound value.
+     *
+     * @param  mixed  $value
+     * @param  string|null  $field
+     * @return \Illuminate\Database\Eloquent\Model|null
+     */
+    public function resolveRouteBinding($value, $field = null)
+    {
+        if (! Api::usesHashids()) {
+            return parent::resolveRouteBinding($value, $field);
+        }
+
+        /** @var \Lunar\Base\BaseModel $model */
+        $model = $this;
+
+        if (empty($field) || $field === $model->getRouteKeyName()) {
+            return $model->newQuery()->where(
+                $field ?: $model->getRouteKeyName(),
+                $this->decodedRouteKey($value)
+            )->firstOrFail();
+        }
+
+        return $model
+            ->newQuery()
+            ->where($field, $value)
+            ->firstOrFail();
+    }
+
+    /**
+     * Encode routeKey.
+     */
+    public function encodedRouteKey(mixed $value): string
+    {
+        return $this->hashIds()->encode($value);
+    }
+
+    /**
+     * Decode hashed routeKey.
+     */
+    public function decodedRouteKey(mixed $value): mixed
+    {
+        return Arr::first($this->hashIds()->decode($value));
+    }
+
+    /**
+     * Get connection name for Hashids.
+     */
+    protected function hashIds(): Hashids
+    {
+        return HashidsFacade::connection($this->getHashidsConnection());
+    }
+
+    /**
+     * Get connection name for Hashids.
+     */
+    protected function getHashidsConnection(): string
+    {
+        /** @var \Lunar\Base\BaseModel $model */
+        $model = $this;
+
+        return HashidsConnections::getModelConnection($model->getMorphClass());
+    }
 }

--- a/tests/api/TestCase.php
+++ b/tests/api/TestCase.php
@@ -104,8 +104,8 @@ abstract class TestCase extends OrchestraTestCase
             \Dystore\Api\JsonApiServiceProvider::class,
 
             // Hashids
-            // \Vinkla\Hashids\HashidsServiceProvider::class,
-            // \Dystore\Api\ApiHashidsServiceProvider::class,
+            \Vinkla\Hashids\HashidsServiceProvider::class,
+            \Dystore\Api\ApiHashidsServiceProvider::class,
         ];
     }
 

--- a/tests/newsletter/TestCase.php
+++ b/tests/newsletter/TestCase.php
@@ -51,8 +51,8 @@ abstract class TestCase extends Orchestra
             \Dystore\Api\JsonApiServiceProvider::class,
 
             // Hashids
-            // \Vinkla\Hashids\HashidsServiceProvider::class,
-            // \Dystore\Api\ApiHashidsServiceProvider::class,
+            \Vinkla\Hashids\HashidsServiceProvider::class,
+            \Dystore\Api\ApiHashidsServiceProvider::class,
 
             // Spatie Newsletter
             \Spatie\Newsletter\NewsletterServiceProvider::class,

--- a/tests/product-notifications/TestCase.php
+++ b/tests/product-notifications/TestCase.php
@@ -73,8 +73,8 @@ abstract class TestCase extends Orchestra
             \Dystore\Api\JsonApiServiceProvider::class,
 
             // Hashids
-            // \Vinkla\Hashids\HashidsServiceProvider::class,
-            // \Dystore\Api\ApiHashidsServiceProvider::class,
+            \Vinkla\Hashids\HashidsServiceProvider::class,
+            \Dystore\Api\ApiHashidsServiceProvider::class,
 
             // Lunar Product Notification
             \Dystore\ProductNotifications\ProductNotificationsServiceProvider::class,

--- a/tests/product-views/TestCase.php
+++ b/tests/product-views/TestCase.php
@@ -71,8 +71,8 @@ abstract class TestCase extends Orchestra
             \Dystore\Api\JsonApiServiceProvider::class,
 
             // Hashids
-            // \Vinkla\Hashids\HashidsServiceProvider::class,
-            // \Dystore\Api\ApiHashidsServiceProvider::class,
+            \Vinkla\Hashids\HashidsServiceProvider::class,
+            \Dystore\Api\ApiHashidsServiceProvider::class,
 
             // Lunar API product views
             \Dystore\ProductViews\ProductViewsServiceProvider::class,

--- a/tests/reviews/TestCase.php
+++ b/tests/reviews/TestCase.php
@@ -60,8 +60,8 @@ abstract class TestCase extends Orchestra
             \Dystore\Api\JsonApiServiceProvider::class,
 
             // Hashids
-            // \Vinkla\Hashids\HashidsServiceProvider::class,
-            // \Dystore\Api\ApiHashidsServiceProvider::class,
+            \Vinkla\Hashids\HashidsServiceProvider::class,
+            \Dystore\Api\ApiHashidsServiceProvider::class,
 
             // Lunar Reviews
             \Dystore\Reviews\ReviewsServiceProvider::class,


### PR DESCRIPTION
## Description

* Laravel json api hashids package version was not compatible with the rest of their packages which caused https://github.com/dystcz/dystore/commit/986f85b416702bd187a3efc6a6b854d774788e4a 
* Added hashids packages `^3.2`
* Uncommented hashids logic

## Related Issues

* #42 
