### PR TITLE
Fix: Fix n+1 queries when including prices to resources

### DIFF
--- a/packages/api/src/Domain/Prices/JsonApi/V1/PriceSchema.php
+++ b/packages/api/src/Domain/Prices/JsonApi/V1/PriceSchema.php
@@ -54,6 +54,7 @@ class PriceSchema extends Schema
     {
         return [
             'currency',
+            'priceable',
 
             ...parent::with(),
         ];
@@ -67,6 +68,7 @@ class PriceSchema extends Schema
         return [
             'currency',
             'customer_group',
+            'priceable',
 
             ...parent::includePaths(),
         ];

--- a/packages/api/src/Domain/ProductVariants/JsonApi/V1/ProductVariantResource.php
+++ b/packages/api/src/Domain/ProductVariants/JsonApi/V1/ProductVariantResource.php
@@ -18,21 +18,23 @@ class ProductVariantResource extends JsonApiResource
         /** @var ProductVariant */
         $model = $this->resource;
 
-        if ($model->relationLoaded('highestPrice') && $model->relationLoaded('variants')) {
-            $model->highestPrice->setRelation('priceable', $model);
-        }
-
-        if ($model->relationLoaded('lowestPrice')) {
-            $model->lowestPrice->setRelation('priceable', $model);
-        }
-
-        if ($model->relationLoaded('prices')) {
-            $model->prices->each(fn ($price) => $price->setRelation('priceable', $model));
-        }
-
-        if ($model->relationLoaded('basePrices')) {
-            $model->prices->each(fn ($price) => $price->setRelation('priceable', $model));
-        }
+        // NOTE: PriceSchema eager loads priceable by default.
+        //
+        // if ($model->relationLoaded('highestPrice') && $model->relationLoaded('variants')) {
+        //     $model->highestPrice->setRelation('priceable', $model);
+        // }
+        //
+        // if ($model->relationLoaded('lowestPrice')) {
+        //     $model->lowestPrice->setRelation('priceable', $model);
+        // }
+        //
+        // if ($model->relationLoaded('prices')) {
+        //     $model->prices->each(fn ($price) => $price->setRelation('priceable', $model));
+        // }
+        //
+        // if ($model->relationLoaded('basePrices')) {
+        //     $model->prices->each(fn ($price) => $price->setRelation('priceable', $model));
+        // }
 
         return parent::attributes($request);
     }


### PR DESCRIPTION
* Eager load `priceable` by default in `PriceSchema`